### PR TITLE
Add more flexibility for credentials secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - Unreleased
+### Added
+- Allow passing an explicit credentials secret to the device instead of depending from the on-board
+  agent registration.
+
 ## [0.11.0-rc.1] - 2020-03-26
 ### Changed
 - Deprecate implicit credentials initialization, the user should now call `astarte_credentials_init`

--- a/include/astarte_credentials.h
+++ b/include/astarte_credentials.h
@@ -115,6 +115,39 @@ astarte_err_t astarte_credentials_get_certificate_common_name(const char *cert_p
 astarte_err_t astarte_credentials_get_key(char *out, size_t length);
 
 /**
+ * @brief get the stored credentials_secret
+ *
+ * @details Get the credentials_secret stored in the NVS, writing it to the out buffer, if it is present.
+ * @param out A pointer to an allocated buffer where the credentials_secret will be written.
+ * @param length The length of the out buffer.
+ * @return The status code, ASTARTE_OK if the credentials_secret was found, ASTARTE_ERR_NOT_FOUND if the
+ * credentials secret is not present in the NVS, another astarte_err_t if an error occurs.
+ */
+astarte_err_t astarte_credentials_get_stored_credentials_secret(char *out, size_t length);
+
+/**
+ * @brief save the credentials_secret in the NVS
+ *
+ * @details Save the credentials_secret in the NVS, where it can be used internally by Astarte Pairing
+ * to obtain Astarte MQTT v1 credentials.
+ * @param credentials_secret A pointer to the buffer that contains the credentials_secret.
+ * @return The status code, ASTARTE_OK if the credentials_secret was correctly written, otherwise an
+ * error code is returned.
+ */
+astarte_err_t astarte_credentials_set_stored_credentials_secret(const char *credentials_secret);
+
+/**
+ * @brief delete the credentials_secret from the NVS
+ *
+ * @details Delete the credentials_secret from the NVS. Keep in mind that if you lose access to the
+ * credentials_secret of a device, you have to unregister it from Astarte before being able to
+ * make it register again.
+ * @return The status code, ASTARTE_OK if the credentials_secret was found, ASTARTE_ERR_NOT_FOUND if
+ * the credentials secret is not present in the NVS, another astarte_err_t if an error occurs.
+ */
+astarte_err_t astarte_credentials_erase_stored_credentials_secret();
+
+/**
  * @brief check if the certificate exists
  *
  * @details Check if the file containing the certificate exists and is readable.

--- a/include/astarte_device.h
+++ b/include/astarte_device.h
@@ -32,6 +32,7 @@ typedef void (*astarte_device_data_event_callback_t)(astarte_device_data_event_t
 typedef struct {
     astarte_device_data_event_callback_t data_event_callback;
     const char *hwid;
+    const char *credentials_secret;
 } astarte_device_config_t;
 
 #ifdef __cplusplus

--- a/include/astarte_pairing.h
+++ b/include/astarte_pairing.h
@@ -22,6 +22,7 @@ struct astarte_pairing_config
     const char* jwt;
     const char* realm;
     const char* hw_id;
+    const char* credentials_secret;
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
Allow the user to pass an explicit credentials secret to the device, or to manipulate the NVS to get/set/delete the credentials secret.

Fix #14 