### PR TITLE
astarte_bson_serializer: fix little endian to host conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.11.1] - Unreleased
+### Fixed
+- Correctly interpret the document length as a 32 bit number when appending a BSON document.
+
 ## [0.11.0] - 2020-04-13
 ### Added
 - Allow passing an explicit credentials secret to the device instead of depending from the on-board

--- a/astarte_bson_serializer.c
+++ b/astarte_bson_serializer.c
@@ -229,7 +229,7 @@ void astarte_bson_serializer_append_document(struct astarte_bson_serializer_t *b
 {
     uint32_t size;
     memcpy(&size, document, sizeof(uint32_t));
-    size = le64toh(size);
+    size = le32toh(size);
 
     astarte_byte_array_append_byte(&bs->ba, BSON_TYPE_DOCUMENT);
     astarte_byte_array_append(&bs->ba, name, strlen(name) + 1);


### PR DESCRIPTION
It was using 64 bits instead of 32 in astarte_bson_serializer_append_document

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>