### PR TITLE
astarte_hwid: allow using UUIDv5 to derive the hardware ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 ### Added
 - Allow sending data to object aggregated interfaces.
+- Allow using UUIDv5 to derive the hardware id.
+
+### Changed
+- The hardware id now will use UUIDv5 by default. This means that if you were using an old version
+  of the SDK, this version will change the generated device id, requiring a new credentials secret.
+  If you need to keep the old device id, disable `Use UUIDv5 to derive the hardware ID` in the
+  Astarte SDK settings with `make menuconfig`.
 
 ## [0.11.1] - Unreleased
 ### Added

--- a/Kconfig
+++ b/Kconfig
@@ -25,4 +25,20 @@ config ASTARTE_CONNECTIVITY_TEST_URL
     default "http://www.example.com"
     help
         The URL used by the SDK to perform a GET request to verify connectivity. It must return an HTTP code < 400 to succeed.
+
+config ASTARTE_HWID_ENABLE_UUID
+    bool "Use UUIDv5 to derive the hardware ID"
+    default y
+    help
+        This option controls how the hardware id is derived.
+        If it's enabled, device-specific data will be feed to UUIDv5 to generate an hardware id.
+        If it's disabled, a SHA256 hash will be used, to maintain compatibility with pre-1.0 behaviour.
+        It is recommended to use UUIDv5 unless there's the need to maintain backwards compatibility (note that changing the setting will change the device-id, invalidating its credentials secret and requiring a new registration).
+
+config ASTARTE_HWID_UUID_NAMESPACE
+    string "The UUIDv5 namespace to use when generating the hardware ID"
+    default "30349dbb-85b6-489e-a8ed-532e65c55c38"
+    help
+        This option controls the UUID namespace that will be fed to the UUIDv5 algorithm when generating the hardware ID (if the "Use UUIDv5 to derive the hardware ID" is enabled).
+
 endmenu

--- a/astarte_hwid.c
+++ b/astarte_hwid.c
@@ -6,6 +6,7 @@
 
 #include <astarte_hwid.h>
 
+#include <uuid.h>
 #include <string.h>
 
 #include <esp_log.h>
@@ -42,6 +43,15 @@ astarte_err_t astarte_hwid_get_id(uint8_t *hardware_id)
 
     ESP_LOGD(HWID_TAG, "Astarte Device SDK running on: %s", info_string);
 
+#ifdef CONFIG_ASTARTE_HWID_ENABLE_UUID
+    uuid_t namespace_uuid;
+    uuid_from_string(CONFIG_ASTARTE_HWID_UUID_NAMESPACE, namespace_uuid);
+
+    uuid_t device_uuid;
+    uuid_generate_v5(namespace_uuid, info_string, strlen(info_string), device_uuid);
+
+    memcpy(hardware_id, device_uuid, 16);
+#else
     uint8_t sha_result[32];
 
     mbedtls_md_context_t ctx;
@@ -55,6 +65,7 @@ astarte_err_t astarte_hwid_get_id(uint8_t *hardware_id)
     mbedtls_md_free(&ctx);
 
     memcpy(hardware_id, sha_result, 16);
+#endif // ASTARTE_HWID_ENABLE_UUID
 
     return ASTARTE_OK;
 }


### PR DESCRIPTION
This is the new default behaviour, but can be toggled from make menuconfig if
the user wants to keep using an hardware ID generated with the old behaviour.

See https://github.com/astarte-platform/astarte/issues/277

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>