### PR TITLE
Improve error management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.11.1] - Unreleased
 ### Added
 - Add a function to unset a properties path.
+- More detailed return error codes.
+
+### Changed
+- Most functions will no longer return ASTARTE_ERR, but a more specific error. Code checking for
+  `err == ASTARTE_ERR` will most likely need to be changed.
 
 ### Fixed
 - Correctly interpret the document length as a 32 bit number when appending a BSON document.

--- a/astarte_hwid.c
+++ b/astarte_hwid.c
@@ -21,7 +21,7 @@ astarte_err_t astarte_hwid_get_id(uint8_t *hardware_id)
     uint8_t mac_addr[6];
     if (esp_efuse_mac_get_default(mac_addr)) {
         ESP_LOGE(HWID_TAG, "Cannot read MAC address.");
-        return ASTARTE_ERR;
+        return ASTARTE_ERR_ESP_SDK;
     }
 
     esp_chip_info_t chip_info;

--- a/include/astarte.h
+++ b/include/astarte.h
@@ -20,8 +20,25 @@
 enum astarte_err_t
 {
     ASTARTE_OK = 0, /**< No errors. */
-    ASTARTE_ERR = 1, /**< A generic error occurred. */
+    ASTARTE_ERR = 1, /**< A generic error occurred. This is usually an internal error in the SDK */
     ASTARTE_ERR_NOT_FOUND = 2, /**< The resource was not found. */
+    ASTARTE_ERR_NO_JWT = 3, /**< ASTARTE_PAIRING_JWT is not configured, device can't be registered */
+    ASTARTE_ERR_OUT_OF_MEMORY = 4, /**< The operation caused an Out of Memory error */
+    ASTARTE_ERR_ESP_SDK = 5, /**< An error caused by the ESP SDK has occurred */
+    ASTARTE_ERR_AUTH = 6, /**< An API call returned an authentication or authorization error */
+    ASTARTE_ERR_ALREADY_EXISTS = 7, /**< Attempted to perform an operation on an already existing resource */
+    ASTARTE_ERR_API = 8, /**< A generic error occurred while calling an Astarte API */
+    ASTARTE_ERR_HTTP = 9, /**< An HTTP request could not be processed */
+    ASTARTE_ERR_NVS = 10, /**< A generic error occurred when dealing with NVS */
+    ASTARTE_ERR_NVS_NOT_INITIALIZED = 11, /**< An error occurred due to an initialization issue with NVS */
+    ASTARTE_ERR_PARTITION_SCHEME = 12, /**< An error occurred due to a partitioning scheme incompatible with the SDK */
+    ASTARTE_ERR_MBED_TLS = 13, /**< An error occurred during an MBED TLS operation */
+    ASTARTE_ERR_IO = 14, /**< An error occurred during a file I/O operation */
+    ASTARTE_ERR_INVALID_INTERFACE_PATH = 15, /**< The Interface Path is not valid */
+    ASTARTE_ERR_INVALID_QOS = 16, /**< The QoS is not valid */
+    ASTARTE_ERR_DEVICE_NOT_READY = 17, /**< Tried to perform an operation on a Device in a non-ready or initialized state */
+    ASTARTE_ERR_PUBLISH = 18, /**< An error occurred while publishing data on MQTT */
+    ASTARTE_ERR_INVALID_INTROSPECTION = 19 /**< The introspection is not valid or empty */
 };
 
 typedef enum astarte_err_t astarte_err_t;


### PR DESCRIPTION
Rather than always returning ASTARTE_ERR, put together a more meaningful error structure and ensure we return it consistently.