### PR TITLE
Add astarte_device_stream_*_with_timestamp functions

### DIFF
--- a/astarte_device.c
+++ b/astarte_device.c
@@ -68,6 +68,7 @@ static void on_incoming(astarte_device_handle_t device, char *topic, int topic_l
 static void on_certificate_error(astarte_device_handle_t device);
 static esp_err_t mqtt_event_handler(esp_mqtt_event_handle_t event);
 static int has_connectivity();
+static void maybe_append_timestamp(struct astarte_bson_serializer_t *bs, uint64_t ts_epoch_millis);
 
 astarte_device_handle_t astarte_device_init(astarte_device_config_t *cfg)
 {
@@ -449,11 +450,18 @@ static astarte_err_t publish_data(astarte_device_handle_t device, const char *in
     return ASTARTE_OK;
 }
 
-astarte_err_t astarte_device_stream_double(astarte_device_handle_t device, const char *interface_name, const char *path, double value, int qos)
+static void maybe_append_timestamp(struct astarte_bson_serializer_t *bs, uint64_t ts_epoch_millis) {
+    if (ts_epoch_millis != ASTARTE_INVALID_TIMESTAMP) {
+        astarte_bson_serializer_append_datetime(bs, "t", ts_epoch_millis);
+    }
+}
+
+astarte_err_t astarte_device_stream_double_with_timestamp(astarte_device_handle_t device, const char *interface_name, const char *path, double value, uint64_t ts_epoch_millis, int qos)
 {
     struct astarte_bson_serializer_t bs;
     astarte_bson_serializer_init(&bs);
     astarte_bson_serializer_append_double(&bs, "v", value);
+    maybe_append_timestamp(&bs, ts_epoch_millis);
     astarte_bson_serializer_append_end_of_document(&bs);
 
     astarte_err_t exit_code = publish_bson(device, interface_name, path, &bs, qos);
@@ -462,11 +470,12 @@ astarte_err_t astarte_device_stream_double(astarte_device_handle_t device, const
     return exit_code;
 }
 
-astarte_err_t astarte_device_stream_integer(astarte_device_handle_t device, const char *interface_name, const char *path, int32_t value, int qos)
+astarte_err_t astarte_device_stream_integer_with_timestamp(astarte_device_handle_t device, const char *interface_name, const char *path, int32_t value, uint64_t ts_epoch_millis, int qos)
 {
     struct astarte_bson_serializer_t bs;
     astarte_bson_serializer_init(&bs);
     astarte_bson_serializer_append_int32(&bs, "v", value);
+    maybe_append_timestamp(&bs, ts_epoch_millis);
     astarte_bson_serializer_append_end_of_document(&bs);
 
     astarte_err_t exit_code = publish_bson(device, interface_name, path, &bs, qos);
@@ -475,11 +484,12 @@ astarte_err_t astarte_device_stream_integer(astarte_device_handle_t device, cons
     return exit_code;
 }
 
-astarte_err_t astarte_device_stream_longinteger(astarte_device_handle_t device, const char *interface_name, const char *path, int64_t value, int qos)
+astarte_err_t astarte_device_stream_longinteger_with_timestamp(astarte_device_handle_t device, const char *interface_name, const char *path, int64_t value, uint64_t ts_epoch_millis, int qos)
 {
     struct astarte_bson_serializer_t bs;
     astarte_bson_serializer_init(&bs);
     astarte_bson_serializer_append_int64(&bs, "v", value);
+    maybe_append_timestamp(&bs, ts_epoch_millis);
     astarte_bson_serializer_append_end_of_document(&bs);
 
     astarte_err_t exit_code = publish_bson(device, interface_name, path, &bs, qos);
@@ -488,11 +498,12 @@ astarte_err_t astarte_device_stream_longinteger(astarte_device_handle_t device, 
     return exit_code;
 }
 
-astarte_err_t astarte_device_stream_boolean(astarte_device_handle_t device, const char *interface_name, const char *path, bool value, int qos)
+astarte_err_t astarte_device_stream_boolean_with_timestamp(astarte_device_handle_t device, const char *interface_name, const char *path, bool value, uint64_t ts_epoch_millis, int qos)
 {
     struct astarte_bson_serializer_t bs;
     astarte_bson_serializer_init(&bs);
     astarte_bson_serializer_append_boolean(&bs, "v", value);
+    maybe_append_timestamp(&bs, ts_epoch_millis);
     astarte_bson_serializer_append_end_of_document(&bs);
 
     astarte_err_t exit_code = publish_bson(device, interface_name, path, &bs, qos);
@@ -501,11 +512,12 @@ astarte_err_t astarte_device_stream_boolean(astarte_device_handle_t device, cons
     return exit_code;
 }
 
-astarte_err_t astarte_device_stream_string(astarte_device_handle_t device, const char *interface_name, const char *path, char *value, int qos)
+astarte_err_t astarte_device_stream_string_with_timestamp(astarte_device_handle_t device, const char *interface_name, const char *path, char *value, uint64_t ts_epoch_millis, int qos)
 {
     struct astarte_bson_serializer_t bs;
     astarte_bson_serializer_init(&bs);
     astarte_bson_serializer_append_string(&bs, "v", value);
+    maybe_append_timestamp(&bs, ts_epoch_millis);
     astarte_bson_serializer_append_end_of_document(&bs);
 
     astarte_err_t exit_code = publish_bson(device, interface_name, path, &bs, qos);
@@ -514,12 +526,12 @@ astarte_err_t astarte_device_stream_string(astarte_device_handle_t device, const
     return exit_code;
 }
 
-astarte_err_t astarte_device_stream_binaryblob(astarte_device_handle_t device, const char *interface_name, const char *path, void *value,
-                                               size_t size, int qos)
+astarte_err_t astarte_device_stream_binaryblob_with_timestamp(astarte_device_handle_t device, const char *interface_name, const char *path, void *value, size_t size, uint64_t ts_epoch_millis, int qos)
 {
     struct astarte_bson_serializer_t bs;
     astarte_bson_serializer_init(&bs);
     astarte_bson_serializer_append_binary(&bs, "v", value, size);
+    maybe_append_timestamp(&bs, ts_epoch_millis);
     astarte_bson_serializer_append_end_of_document(&bs);
 
     astarte_err_t exit_code = publish_bson(device, interface_name, path, &bs, qos);
@@ -528,11 +540,12 @@ astarte_err_t astarte_device_stream_binaryblob(astarte_device_handle_t device, c
     return exit_code;
 }
 
-astarte_err_t astarte_device_stream_datetime(astarte_device_handle_t device, const char *interface_name, const char *path, int64_t value, int qos)
+astarte_err_t astarte_device_stream_datetime_with_timestamp(astarte_device_handle_t device, const char *interface_name, const char *path, int64_t value, uint64_t ts_epoch_millis, int qos)
 {
     struct astarte_bson_serializer_t bs;
     astarte_bson_serializer_init(&bs);
     astarte_bson_serializer_append_datetime(&bs, "v", value);
+    maybe_append_timestamp(&bs, ts_epoch_millis);
     astarte_bson_serializer_append_end_of_document(&bs);
 
     astarte_err_t exit_code = publish_bson(device, interface_name, path, &bs, qos);
@@ -541,19 +554,60 @@ astarte_err_t astarte_device_stream_datetime(astarte_device_handle_t device, con
     return exit_code;
 }
 
-astarte_err_t astarte_device_stream_aggregate(astarte_device_handle_t device,
-                                              const char *interface_name, const char *path_prefix,
-                                              const void *bson_document, int qos)
+astarte_err_t astarte_device_stream_aggregate_with_timestamp(astarte_device_handle_t device, const char *interface_name, const char *path_prefix, const void *bson_document, uint64_t ts_epoch_millis, int qos)
 {
     struct astarte_bson_serializer_t bs;
     astarte_bson_serializer_init(&bs);
     astarte_bson_serializer_append_document(&bs, "v", bson_document);
+    maybe_append_timestamp(&bs, ts_epoch_millis);
     astarte_bson_serializer_append_end_of_document(&bs);
 
     astarte_err_t exit_code = publish_bson(device, interface_name, path_prefix, &bs, qos);
 
     astarte_bson_serializer_destroy(&bs);
     return exit_code;
+}
+
+astarte_err_t astarte_device_stream_double(astarte_device_handle_t device, const char *interface_name, const char *path, double value, int qos)
+{
+    return astarte_device_stream_double_with_timestamp(device, interface_name, path, value, ASTARTE_INVALID_TIMESTAMP, qos);
+}
+
+astarte_err_t astarte_device_stream_integer(astarte_device_handle_t device, const char *interface_name, const char *path, int32_t value, int qos)
+{
+    return astarte_device_stream_integer_with_timestamp(device, interface_name, path, value, ASTARTE_INVALID_TIMESTAMP, qos);
+}
+
+astarte_err_t astarte_device_stream_longinteger(astarte_device_handle_t device, const char *interface_name, const char *path, int64_t value, int qos)
+{
+    return astarte_device_stream_longinteger_with_timestamp(device, interface_name, path, value, ASTARTE_INVALID_TIMESTAMP, qos);
+}
+
+astarte_err_t astarte_device_stream_boolean(astarte_device_handle_t device, const char *interface_name, const char *path, bool value, int qos)
+{
+    return astarte_device_stream_boolean_with_timestamp(device, interface_name, path, value, ASTARTE_INVALID_TIMESTAMP, qos);
+}
+
+astarte_err_t astarte_device_stream_string(astarte_device_handle_t device, const char *interface_name, const char *path, char *value, int qos)
+{
+    return astarte_device_stream_string_with_timestamp(device, interface_name, path, value, ASTARTE_INVALID_TIMESTAMP, qos);
+}
+
+astarte_err_t astarte_device_stream_binaryblob(astarte_device_handle_t device, const char *interface_name, const char *path, void *value, size_t size, int qos)
+{
+    return astarte_device_stream_binaryblob_with_timestamp(device, interface_name, path, value, size, ASTARTE_INVALID_TIMESTAMP, qos);
+}
+
+astarte_err_t astarte_device_stream_datetime(astarte_device_handle_t device, const char *interface_name, const char *path, int64_t value, int qos)
+{
+    return astarte_device_stream_datetime_with_timestamp(device, interface_name, path, value, ASTARTE_INVALID_TIMESTAMP, qos);
+}
+
+astarte_err_t astarte_device_stream_aggregate(astarte_device_handle_t device,
+                                              const char *interface_name, const char *path_prefix,
+                                              const void *bson_document, int qos)
+{
+    return astarte_device_stream_aggregate_with_timestamp(device, interface_name, path_prefix, bson_document, ASTARTE_INVALID_TIMESTAMP, qos);
 }
 
 astarte_err_t astarte_device_set_double_property(astarte_device_handle_t device,

--- a/include/astarte_device.h
+++ b/include/astarte_device.h
@@ -18,6 +18,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#define ASTARTE_INVALID_TIMESTAMP 0
+
 typedef struct astarte_device_t *astarte_device_handle_t;
 
 typedef struct {
@@ -118,6 +120,24 @@ void astarte_device_start(astarte_device_handle_t device);
 astarte_err_t astarte_device_stream_double(astarte_device_handle_t device, const char *interface_name, const char *path, double value, int qos);
 
 /**
+ * @brief send a double value on a datastream endpoint with an explicit timestamp.
+ *
+ * @details This function sends a double value on a path of a given datastream interface.
+ * @param device A started Astarte device handle.
+ * @param interface_name A string containing the name of the interface.
+ * @param path A string containing the path (beginning with /).
+ * @param value The value to be sent.
+ * @param ts_epoch_millis The timestamp of the datastream. This is useful only on mappings with
+ * explicit_timestamp set to true and it's represented as milliseconds since epoch. A value of
+ * ASTARTE_INVALID_TIMESTAMP is ignored.
+ * @param qos The MQTT QoS to be used for the publish (0, 1 or 2).
+ * @return ASTARTE_OK if the value was correctly published, another astarte_err_t otherwise. Note that this
+ * just checks that the publish sequence correctly started, i.e. it doesn't wait for PUBACK for QoS 1 messages
+ * or for PUBCOMP for QoS 2 messages
+ */
+astarte_err_t astarte_device_stream_double_with_timestamp(astarte_device_handle_t device, const char *interface_name, const char *path, double value, uint64_t ts_epoch_millis, int qos);
+
+/**
  * @brief send a 32 bit integer value on a datastream endpoint.
  *
  * @details This function sends a 32 bit int value on a path of a given datastream interface.
@@ -131,6 +151,24 @@ astarte_err_t astarte_device_stream_double(astarte_device_handle_t device, const
  * or for PUBCOMP for QoS 2 messages
  */
 astarte_err_t astarte_device_stream_integer(astarte_device_handle_t device, const char *interface_name, const char *path, int32_t value, int qos);
+
+/**
+ * @brief send a 32 bit integer value on a datastream endpoint with an explicit timestamp.
+ *
+ * @details This function sends a 32 bit int value on a path of a given datastream interface.
+ * @param device A started Astarte device handle.
+ * @param interface_name A string containing the name of the interface.
+ * @param path A string containing the path (beginning with /).
+ * @param value The value to be sent.
+ * @param ts_epoch_millis The timestamp of the datastream. This is useful only on mappings with
+ * explicit_timestamp set to true and it's represented as milliseconds since epoch. A value of
+ * ASTARTE_INVALID_TIMESTAMP is ignored.
+ * @param qos The MQTT QoS to be used for the publish (0, 1 or 2).
+ * @return ASTARTE_OK if the value was correctly published, another astarte_err_t otherwise. Note that this
+ * just checks that the publish sequence correctly started, i.e. it doesn't wait for PUBACK for QoS 1 messages
+ * or for PUBCOMP for QoS 2 messages
+ */
+astarte_err_t astarte_device_stream_integer_with_timestamp(astarte_device_handle_t device, const char *interface_name, const char *path, int32_t value, uint64_t ts_epoch_millis, int qos);
 
 /**
  * @brief send a 64 bit integer value on a datastream endpoint.
@@ -148,6 +186,24 @@ astarte_err_t astarte_device_stream_integer(astarte_device_handle_t device, cons
 astarte_err_t astarte_device_stream_longinteger(astarte_device_handle_t device, const char *interface_name, const char *path, int64_t value, int qos);
 
 /**
+ * @brief send a 64 bit integer value on a datastream endpoint with an explicit timestamp.
+ *
+ * @details This function sends a 64 bit int value on a path of a given datastream interface.
+ * @param device A started Astarte device handle.
+ * @param interface_name A string containing the name of the interface.
+ * @param path A string containing the path (beginning with /).
+ * @param value The value to be sent.
+ * @param ts_epoch_millis The timestamp of the datastream. This is useful only on mappings with
+ * explicit_timestamp set to true and it's represented as milliseconds since epoch. A value of
+ * ASTARTE_INVALID_TIMESTAMP is ignored.
+ * @param qos The MQTT QoS to be used for the publish (0, 1 or 2).
+ * @return ASTARTE_OK if the value was correctly published, another astarte_err_t otherwise. Note that this
+ * just checks that the publish sequence correctly started, i.e. it doesn't wait for PUBACK for QoS 1 messages
+ * or for PUBCOMP for QoS 2 messages
+ */
+astarte_err_t astarte_device_stream_longinteger_with_timestamp(astarte_device_handle_t device, const char *interface_name, const char *path, int64_t value, uint64_t ts_epoch_millis, int qos);
+
+/**
  * @brief send a boolean value on a datastream endpoint.
  *
  * @details This function sends a boolean value on a path of a given datastream interface.
@@ -163,6 +219,24 @@ astarte_err_t astarte_device_stream_longinteger(astarte_device_handle_t device, 
 astarte_err_t astarte_device_stream_boolean(astarte_device_handle_t device, const char *interface_name, const char *path, bool value, int qos);
 
 /**
+ * @brief send a boolean value on a datastream endpoint with an explicit timestamp.
+ *
+ * @details This function sends a boolean value on a path of a given datastream interface.
+ * @param device A started Astarte device handle.
+ * @param interface_name A string containing the name of the interface.
+ * @param path A string containing the path (beginning with /).
+ * @param value The value to be sent (0 or 1).
+ * @param ts_epoch_millis The timestamp of the datastream. This is useful only on mappings with
+ * explicit_timestamp set to true and it's represented as milliseconds since epoch. A value of
+ * ASTARTE_INVALID_TIMESTAMP is ignored.
+ * @param qos The MQTT QoS to be used for the publish (0, 1 or 2).
+ * @return ASTARTE_OK if the value was correctly published, another astarte_err_t otherwise. Note that this
+ * just checks that the publish sequence correctly started, i.e. it doesn't wait for PUBACK for QoS 1 messages
+ * or for PUBCOMP for QoS 2 messages
+ */
+    astarte_err_t astarte_device_stream_boolean_with_timestamp(astarte_device_handle_t device, const char *interface_name, const char *path, bool value, uint64_t ts_epoch_millis, int qos);
+
+/**
  * @brief send a UTF8 encoded string on a datastream endpoint.
  *
  * @details This function sends a UTF8 encoded string on a path of a given datastream interface.
@@ -176,6 +250,24 @@ astarte_err_t astarte_device_stream_boolean(astarte_device_handle_t device, cons
  * or for PUBCOMP for QoS 2 messages
  */
 astarte_err_t astarte_device_stream_string(astarte_device_handle_t device, const char *interface_name, const char *path, char *value, int qos);
+
+/**
+ * @brief send a UTF8 encoded string on a datastream endpoint with an explicit timestamp.
+ *
+ * @details This function sends a UTF8 encoded string on a path of a given datastream interface.
+ * @param device A started Astarte device handle.
+ * @param interface_name A string containing the name of the interface.
+ * @param path A string containing the path (beginning with /).
+ * @param value The value to be sent (a NULL terminated string).
+ * @param ts_epoch_millis The timestamp of the datastream. This is useful only on mappings with
+ * explicit_timestamp set to true and it's represented as milliseconds since epoch. A value of
+ * ASTARTE_INVALID_TIMESTAMP is ignored.
+ * @param qos The MQTT QoS to be used for the publish (0, 1 or 2).
+ * @return ASTARTE_OK if the value was correctly published, another astarte_err_t otherwise. Note that this
+ * just checks that the publish sequence correctly started, i.e. it doesn't wait for PUBACK for QoS 1 messages
+ * or for PUBCOMP for QoS 2 messages
+ */
+astarte_err_t astarte_device_stream_string_with_timestamp(astarte_device_handle_t device, const char *interface_name, const char *path, char *value, uint64_t ts_epoch_millis, int qos);
 
 /**
  * @brief send a binary value on a datastream endpoint.
@@ -195,6 +287,25 @@ astarte_err_t astarte_device_stream_binaryblob(astarte_device_handle_t device, c
                                                size_t size, int qos);
 
 /**
+ * @brief send a binary value on a datastream endpoint with an explicit timestamp.
+ *
+ * @details This function sends a binary value on a path of a given datastream interface.
+ * @param device A started Astarte device handle.
+ * @param interface_name A string containing the name of the interface.
+ * @param path A string containing the path (beginning with /).
+ * @param value A pointer to the binary data to be sent.
+ * @param size The length in bytes of the binary data to be sent.
+ * @param ts_epoch_millis The timestamp of the datastream. This is useful only on mappings with
+ * explicit_timestamp set to true and it's represented as milliseconds since epoch. A value of
+ * ASTARTE_INVALID_TIMESTAMP is ignored.
+ * @param qos The MQTT QoS to be used for the publish (0, 1 or 2).
+ * @return ASTARTE_OK if the value was correctly published, another astarte_err_t otherwise. Note that this
+ * just checks that the publish sequence correctly started, i.e. it doesn't wait for PUBACK for QoS 1 messages
+ * or for PUBCOMP for QoS 2 messages
+ */
+astarte_err_t astarte_device_stream_binaryblob_with_timestamp(astarte_device_handle_t device, const char *interface_name, const char *path, void *value, size_t size, uint64_t ts_epoch_millis, int qos);
+
+/**
  * @brief send a datetime value on a datastream endpoint.
  *
  * @details This function sends a datetime value on a path of a given datastream interface. The datetime
@@ -209,6 +320,25 @@ astarte_err_t astarte_device_stream_binaryblob(astarte_device_handle_t device, c
  * or for PUBCOMP for QoS 2 messages
  */
 astarte_err_t astarte_device_stream_datetime(astarte_device_handle_t device, const char *interface_name, const char *path, int64_t value, int qos);
+
+/**
+ * @brief send a datetime value on a datastream endpoint with an explicit timestamp.
+ *
+ * @details This function sends a datetime value on a path of a given datastream interface. The datetime
+ * represents the number of milliseconds since Unix epoch (1970-01-01).
+ * @param device A started Astarte device handle.
+ * @param interface_name A string containing the name of the interface.
+ * @param path A string containing the path (beginning with /).
+ * @param value The value to be sent, representing the number of milliseconds since Unix epoch (1970-01-01).
+ * @param ts_epoch_millis The timestamp of the datastream. This is useful only on mappings with
+ * explicit_timestamp set to true and it's represented as milliseconds since epoch. A value of
+ * ASTARTE_INVALID_TIMESTAMP is ignored.
+ * @param qos The MQTT QoS to be used for the publish (0, 1 or 2).
+ * @return ASTARTE_OK if the value was correctly published, another astarte_err_t otherwise. Note that this
+ * just checks that the publish sequence correctly started, i.e. it doesn't wait for PUBACK for QoS 1 messages
+ * or for PUBCOMP for QoS 2 messages
+ */
+astarte_err_t astarte_device_stream_datetime_with_timestamp(astarte_device_handle_t device, const char *interface_name, const char *path, int64_t value, uint64_t ts_epoch_millis, int qos);
 
 /**
  * @brief send an aggregate value on a datastream endpoint of an interface with object aggregation.
@@ -237,6 +367,39 @@ astarte_err_t astarte_device_stream_datetime(astarte_device_handle_t device, con
 astarte_err_t astarte_device_stream_aggregate(astarte_device_handle_t device,
                                               const char *interface_name, const char *path_prefix,
                                               const void *bson_document, int qos);
+
+/**
+ * @brief send an aggregate value on a datastream endpoint of an interface with object aggregation
+ * with an explicit timestamp.
+ *
+ * @details This function sends an aggregate value on a path of a given datastream interface. The
+ * value is represented with a BSON document that can be built with astarte_bson_serializer.
+ * @param device A started Astarte device handle.
+ * @param interface_name A string containing the name of the interface.
+ * @param path_prefix A string containing the path prefix of the aggregate (beginning with /).
+ * The path prefix is the common prefix of the endpoints in the aggregate interface.
+ * @param bson_document A pointer to the document buffer containing the aggregate. Here's an example
+ * of how you can obtain the bson_document for an AirSensor interface containing 3 endpoints:
+ *
+ *  astarte_bson_serializer_init(&bs);
+ *  astarte_bson_serializer_append_double(&bs, "co2", 4.0);
+ *  astarte_bson_serializer_append_double(&bs, "temperature", 20.0);
+ *  astarte_bson_serializer_append_double(&bs, "humidity", 77.2);
+ *  astarte_bson_serializer_append_end_of_document(&bs);
+ *  int size;
+ *  const void *document = astarte_bson_serializer_get_document(&bs, &size);
+ * @param ts_epoch_millis The timestamp of the datastream. This is useful only on mappings with
+ * explicit_timestamp set to true and it's represented as milliseconds since epoch. A value of
+ * ASTARTE_INVALID_TIMESTAMP is ignored.
+ * @param qos The MQTT QoS to be used for the publish (0, 1 or 2).
+ * @return ASTARTE_OK if the value was correctly published, another astarte_err_t otherwise. Note
+ * that this just checks that the publish sequence correctly started, i.e. it doesn't wait for
+ * PUBACK for QoS 1 messages or for PUBCOMP for QoS 2 messages
+ */
+astarte_err_t astarte_device_stream_aggregate_with_timestamp(astarte_device_handle_t device,
+                                                             const char *interface_name, const char *path_prefix,
+                                                             const void *bson_document, uint64_t ts_epoch_millis, int qos);
+
 /**
  * @brief send a double value on a properties endpoint.
  *


### PR DESCRIPTION
Allow sending explicit timestamps to mappings that support them.

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>