### PR TITLE
toggle_button example: fix relative path in CMakeLists.txt

### DIFF
--- a/examples/toggle_led/CMakeLists.txt
+++ b/examples/toggle_led/CMakeLists.txt
@@ -4,6 +4,6 @@ cmake_minimum_required(VERSION 3.5)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 
-set(EXTRA_COMPONENT_DIRS ${CMAKE_SOURCE_DIR}/../../../)
+set(EXTRA_COMPONENT_DIRS ${CMAKE_SOURCE_DIR}/../..)
 
 project(toggle-led)


### PR DESCRIPTION
Fix build error with cmake esp-idf (esp-idf >= 4.0).