### PR TITLE
astarte_device: add user connection/disconnection callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.0.0-beta.2] - Unreleased
 ### Added
 - Add `astarte_device_stop` function to stop the internal MQTT client.
+- Add connection and disconnection callbacks called after device connection/disconnection.
 
 ## [1.0.0-beta.1] - 2021-02-16
 ### Added

--- a/astarte_device.c
+++ b/astarte_device.c
@@ -47,6 +47,8 @@ struct astarte_device_t
     char *key_pem;
     bool connected;
     astarte_device_data_event_callback_t data_event_callback;
+    astarte_device_connection_event_callback_t connection_event_callback;
+    astarte_device_disconnection_event_callback_t disconnection_event_callback;
     esp_mqtt_client_handle_t mqtt_client;
     TaskHandle_t reinit_task_handle;
     SemaphoreHandle_t reinit_mutex;
@@ -123,6 +125,8 @@ astarte_device_handle_t astarte_device_init(astarte_device_config_t *cfg)
     }
 
     ret->data_event_callback = cfg->data_event_callback;
+    ret->connection_event_callback = cfg->connection_event_callback;
+    ret->disconnection_event_callback = cfg->disconnection_event_callback;
 
     return ret;
 
@@ -428,6 +432,12 @@ astarte_err_t astarte_device_stop(astarte_device_handle_t device)
     }
 
     xSemaphoreGive(device->reinit_mutex);
+
+    if (ret == ASTARTE_OK) {
+        // If we succesfully disconnected, call on_disconnected since
+        // MQTT_EVENT_DISCONNECTED is not triggered for manual disconnections
+        on_disconnected(device);
+    }
 
     return ret;
 }
@@ -848,6 +858,13 @@ static void on_connected(astarte_device_handle_t device, int session_present)
 {
     device->connected = true;
 
+    if (device->connection_event_callback) {
+        astarte_device_connection_event_t event
+            = { .device = device, .session_present = session_present };
+
+        device->connection_event_callback(&event);
+    }
+
     if (session_present) {
         return;
     }
@@ -859,6 +876,14 @@ static void on_connected(astarte_device_handle_t device, int session_present)
 static void on_disconnected(astarte_device_handle_t device)
 {
     device->connected = false;
+
+    if (device->disconnection_event_callback) {
+        astarte_device_disconnection_event_t event = {
+            .device = device,
+        };
+
+        device->disconnection_event_callback(&event);
+    }
 }
 
 static void on_incoming(

--- a/examples/toggle_led/main/app_main.c
+++ b/examples/toggle_led/main/app_main.c
@@ -125,6 +125,16 @@ static void astarte_data_events_handler(astarte_device_data_event_t *event)
     }
 }
 
+static void astarte_connection_events_handler(astarte_device_connection_event_t *event)
+{
+    ESP_LOGI(TAG, "Astarte device connected, session_present: %d", event->session_present);
+}
+
+static void astarte_disconnection_events_handler(astarte_device_disconnection_event_t *event)
+{
+    ESP_LOGI(TAG, "Astarte device disconnected");
+}
+
 static void astarte_example_task(void *ctx)
 {
     /*
@@ -134,6 +144,8 @@ static void astarte_example_task(void *ctx)
      */
     astarte_device_config_t cfg = {
         .data_event_callback = astarte_data_events_handler,
+        .connection_event_callback = astarte_connection_events_handler,
+        .disconnection_event_callback = astarte_disconnection_events_handler,
     };
 
     astarte_device_handle_t device = astarte_device_init(&cfg);

--- a/include/astarte_device.h
+++ b/include/astarte_device.h
@@ -35,7 +35,27 @@ typedef void (*astarte_device_data_event_callback_t)(astarte_device_data_event_t
 
 typedef struct
 {
+    astarte_device_handle_t device;
+    int session_present;
+} astarte_device_connection_event_t;
+
+typedef void (*astarte_device_connection_event_callback_t)(
+    astarte_device_connection_event_t *event);
+
+typedef struct
+{
+    astarte_device_handle_t device;
+    int session_present;
+} astarte_device_disconnection_event_t;
+
+typedef void (*astarte_device_disconnection_event_callback_t)(
+    astarte_device_disconnection_event_t *event);
+
+typedef struct
+{
     astarte_device_data_event_callback_t data_event_callback;
+    astarte_device_connection_event_callback_t connection_event_callback;
+    astarte_device_disconnection_event_callback_t disconnection_event_callback;
     const char *hwid;
     const char *credentials_secret;
 } astarte_device_config_t;


### PR DESCRIPTION
Allow the caller to be notified when the device connects or disconnects.
Fix #50

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>