### PR TITLE
astarte_device: return astarte_err_t from astarte_device_start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add `astarte_device_stop` function to stop the internal MQTT client.
 - Add connection and disconnection callbacks called after device connection/disconnection.
 
+### Changed
+- `astarte_device_start` now returns `astarte_err_t` to check if the device was succesfully started.
+
 ## [1.0.0-beta.1] - 2021-02-16
 ### Added
 - Allow sending data to object aggregated interfaces.

--- a/astarte_device.c
+++ b/astarte_device.c
@@ -405,15 +405,24 @@ astarte_err_t astarte_device_add_interface(astarte_device_handle_t device,
     return ASTARTE_OK;
 }
 
-void astarte_device_start(astarte_device_handle_t device)
+astarte_err_t astarte_device_start(astarte_device_handle_t device)
 {
     if (xSemaphoreTake(device->reinit_mutex, (TickType_t) 10) == pdFALSE) {
         ESP_LOGE(TAG, "Trying to start device that is being reinitialized");
-        return;
+        return ASTARTE_ERR_DEVICE_NOT_READY;
     }
 
-    esp_mqtt_client_start(device->mqtt_client);
+    astarte_err_t ret = ASTARTE_OK;
+
+    esp_err_t err = esp_mqtt_client_start(device->mqtt_client);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to stop MQTT client: %s", esp_err_to_name(err));
+        ret = ASTARTE_ERR;
+    }
+
     xSemaphoreGive(device->reinit_mutex);
+
+    return ret;
 }
 
 astarte_err_t astarte_device_stop(astarte_device_handle_t device)

--- a/examples/toggle_led/main/app_main.c
+++ b/examples/toggle_led/main/app_main.c
@@ -156,7 +156,10 @@ static void astarte_example_task(void *ctx)
 
     astarte_device_add_interface(device, "org.astarteplatform.esp32.DeviceDatastream", 0, 2);
     astarte_device_add_interface(device, "org.astarteplatform.esp32.ServerDatastream", 0, 1);
-    astarte_device_start(device);
+    if (astarte_device_start(device) != ASTARTE_OK) {
+        ESP_LOGE(TAG, "Failed to start astarte device");
+        return;
+    }
 
     ESP_LOGI(TAG, "[APP] Encoded device ID: %s", astarte_device_get_encoded_id(device));
 

--- a/include/astarte_device.h
+++ b/include/astarte_device.h
@@ -125,8 +125,9 @@ astarte_err_t astarte_device_add_interface(astarte_device_handle_t device,
  *
  * @details This function starts the device, making it connect to the broker and perform its work.
  * @param device A valid Astarte device handle.
+ * @return ASTARTE_OK if the device was succesfully started, another astarte_err_t otherwise.
  */
-void astarte_device_start(astarte_device_handle_t device);
+astarte_err_t astarte_device_start(astarte_device_handle_t device);
 
 /**
  * @brief stop Astarte device.


### PR DESCRIPTION
Allow failures to be propagated to the caller
Fix #55

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>