### PR TITLE
app_main: run clang-format

### DIFF
--- a/examples/toggle_led/main/app_main.c
+++ b/examples/toggle_led/main/app_main.c
@@ -111,9 +111,8 @@ static void astarte_data_events_handler(astarte_device_data_event_t *event)
     ESP_LOGI(TAG, "Got Astarte data event, interface_name: %s, path: %s, bson_type: %d",
         event->interface_name, event->path, event->bson_value_type);
 
-    if (strcmp(event->interface_name, "org.astarteplatform.esp32.ServerDatastream") == 0 &&
-            strcmp(event->path, "/led") == 0 &&
-            event->bson_value_type == BSON_TYPE_BOOLEAN) {
+    if (strcmp(event->interface_name, "org.astarteplatform.esp32.ServerDatastream") == 0
+        && strcmp(event->path, "/led") == 0 && event->bson_value_type == BSON_TYPE_BOOLEAN) {
         int led_state = astarte_bson_value_to_int8(event->bson_value);
         if (led_state) {
             ESP_LOGI(TAG, "Turning led on");
@@ -165,9 +164,11 @@ static void astarte_example_task(void *ctx)
         if (xQueueReceive(button_evt_queue, &io_num, portMAX_DELAY)) {
             if (io_num == BUTTON_GPIO) {
                 // Button pressed, send 1 and current uptime
-                astarte_device_stream_boolean(device, "org.astarteplatform.esp32.DeviceDatastream", "/userButton", 1, 0);
+                astarte_device_stream_boolean(
+                    device, "org.astarteplatform.esp32.DeviceDatastream", "/userButton", 1, 0);
                 int uptimeSeconds = (xTaskGetTickCount() * portTICK_PERIOD_MS) / 1000;
-                astarte_device_stream_integer(device, "org.astarteplatform.esp32.DeviceDatastream", "/uptimeSeconds", uptimeSeconds, 0);
+                astarte_device_stream_integer(device, "org.astarteplatform.esp32.DeviceDatastream",
+                    "/uptimeSeconds", uptimeSeconds, 0);
             }
         }
     }


### PR DESCRIPTION
This was missed when the whole codebase was reformatted

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>