### PR TITLE
Change astarte_device_add_interface API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.0-rc.0] - Unreleased
+### Changed
+- `astarte_device_add_interface` **incompatible API change**, the caller now has to provide a
+  pointer to an `astarte_interface_t` struct.
+- Make sure the device only subscribes to server owned interfaces. This avoids that published
+  messages are sent back to the device.
+
 ## [1.0.0-beta.2] - 2021-03-23
 ### Added
 - Add `astarte_device_stop` function to stop the internal MQTT client.

--- a/astarte_device.c
+++ b/astarte_device.c
@@ -10,6 +10,7 @@
 #include <astarte_bson_serializer.h>
 #include <astarte_credentials.h>
 #include <astarte_hwid.h>
+#include <astarte_list.h>
 #include <astarte_pairing.h>
 
 #include <mqtt_client.h>
@@ -42,7 +43,6 @@ struct astarte_device_t
     char *credentials_secret;
     char *device_topic;
     int device_topic_len;
-    char *introspection_string;
     char *client_cert_pem;
     char *key_pem;
     bool connected;
@@ -52,6 +52,7 @@ struct astarte_device_t
     esp_mqtt_client_handle_t mqtt_client;
     TaskHandle_t reinit_task_handle;
     SemaphoreHandle_t reinit_mutex;
+    struct astarte_list_head_t interfaces_list;
 };
 
 static void astarte_device_reinit_task(void *ctx);
@@ -124,6 +125,7 @@ astarte_device_handle_t astarte_device_init(astarte_device_config_t *cfg)
         goto init_failed;
     }
 
+    astarte_list_init(&ret->interfaces_list);
     ret->data_event_callback = cfg->data_event_callback;
     ret->connection_event_callback = cfg->connection_event_callback;
     ret->disconnection_event_callback = cfg->disconnection_event_callback;
@@ -360,46 +362,37 @@ void astarte_device_destroy(astarte_device_handle_t device)
     free(device->device_topic);
     free(device->client_cert_pem);
     free(device->key_pem);
-    free(device->introspection_string);
     free(device->encoded_hwid);
     free(device->credentials_secret);
+    struct astarte_list_head_t *item;
+    struct astarte_list_head_t *tmp;
+    MUTABLE_LIST_FOR_EACH(item, tmp, &device->interfaces_list)
+    {
+        struct astarte_ptr_list_entry_t *entry
+            = GET_LIST_ENTRY(item, struct astarte_ptr_list_entry_t, head);
+        free(entry);
+    }
     free(device);
 }
 
-astarte_err_t astarte_device_add_interface(astarte_device_handle_t device,
-    const char *interface_name, int major_version, int minor_version)
+astarte_err_t astarte_device_add_interface(
+    astarte_device_handle_t device, const astarte_interface_t *interface)
 {
     if (xSemaphoreTake(device->reinit_mutex, (TickType_t) 10) == pdFALSE) {
         ESP_LOGE(TAG, "Trying to add an interface to a device that is being reinitialized");
         return ASTARTE_ERR;
     }
 
-    char new_interface[INTROSPECTION_INTERFACE_LENGTH];
-    snprintf(new_interface, INTROSPECTION_INTERFACE_LENGTH, "%s:%d:%d", interface_name,
-        major_version, minor_version);
-
-    if (!device->introspection_string) {
-        device->introspection_string = strdup(new_interface);
-        if (!device->introspection_string) {
-            ESP_LOGE(TAG, "Out of memory %s: %d", __FILE__, __LINE__);
-            xSemaphoreGive(device->reinit_mutex);
-            return ASTARTE_ERR_OUT_OF_MEMORY;
-        }
-    } else {
-        // + 2 for ; and terminator
-        int len = strlen(device->introspection_string) + strlen(new_interface) + 2;
-        char *new_introspection_string = calloc(1, len);
-        if (!new_introspection_string) {
-            ESP_LOGE(TAG, "Out of memory %s: %d", __FILE__, __LINE__);
-            xSemaphoreGive(device->reinit_mutex);
-            return ASTARTE_ERR_OUT_OF_MEMORY;
-        }
-
-        snprintf(
-            new_introspection_string, len, "%s;%s", device->introspection_string, new_interface);
-        free(device->introspection_string);
-        device->introspection_string = new_introspection_string;
+    struct astarte_ptr_list_entry_t *entry = calloc(1, sizeof(struct astarte_ptr_list_entry_t));
+    if (!entry) {
+        ESP_LOGE(TAG, "Out of memory %s: %d", __FILE__, __LINE__);
+        xSemaphoreGive(device->reinit_mutex);
+        return ASTARTE_ERR_OUT_OF_MEMORY;
     }
+
+    entry->value = interface;
+
+    astarte_list_append(&device->interfaces_list, &entry->head);
 
     xSemaphoreGive(device->reinit_mutex);
     return ASTARTE_OK;
@@ -790,18 +783,13 @@ exit:
 
 static astarte_err_t check_device(astarte_device_handle_t device)
 {
-    if (!device->introspection_string) {
-        ESP_LOGE(TAG, "NULL introspection_string in send_introspection");
-        return ASTARTE_ERR_INVALID_INTROSPECTION;
-    }
-
     if (!device->mqtt_client) {
-        ESP_LOGE(TAG, "NULL mqtt_client in send_introspection");
+        ESP_LOGE(TAG, "NULL mqtt_client");
         return ASTARTE_ERR;
     }
 
     if (!device->device_topic) {
-        ESP_LOGE(TAG, "NULL device_topic in send_introspection");
+        ESP_LOGE(TAG, "NULL device_topic");
         return ASTARTE_ERR;
     }
 
@@ -815,9 +803,36 @@ static void send_introspection(astarte_device_handle_t device)
     }
 
     esp_mqtt_client_handle_t mqtt = device->mqtt_client;
-    int len = strlen(device->introspection_string);
-    ESP_LOGI(TAG, "Publishing introspection: %s", device->introspection_string);
-    esp_mqtt_client_publish(mqtt, device->device_topic, device->introspection_string, len, 2, 0);
+
+    char introspection_string[512] = { 0 };
+    size_t total_written = 0;
+    struct astarte_list_head_t *item;
+    LIST_FOR_EACH(item, &device->interfaces_list)
+    {
+        struct astarte_ptr_list_entry_t *entry
+            = GET_LIST_ENTRY(item, struct astarte_ptr_list_entry_t, head);
+        const astarte_interface_t *interface = entry->value;
+        char interface_entry[128];
+        snprintf(interface_entry, 128, "%s:%d:%d;", interface->name, interface->major_version,
+            interface->minor_version);
+
+        size_t to_be_written = strlen(interface_entry);
+        // + 1 because we need space for the terminator
+        if (total_written + to_be_written + 1 > 512) {
+            ESP_LOGE(TAG, "Introspection string is too long, cannot publish");
+            return;
+        }
+        strcat(introspection_string, interface_entry);
+        total_written += to_be_written;
+    }
+    int len = strlen(introspection_string);
+    // Remove last ; from introspection
+    introspection_string[len - 1] = 0;
+    // Decrease len accordingly
+    len -= 1;
+
+    ESP_LOGI(TAG, "Publishing introspection: %s", introspection_string);
+    esp_mqtt_client_publish(mqtt, device->device_topic, introspection_string, len, 2, 0);
 }
 
 static void setup_subscriptions(astarte_device_handle_t device)
@@ -830,36 +845,23 @@ static void setup_subscriptions(astarte_device_handle_t device)
 
     esp_mqtt_client_handle_t mqtt = device->mqtt_client;
 
-    // TODO: should we just subscribe to device_topic/#?
     // Subscribe to control messages
-    snprintf(topic, TOPIC_LENGTH, "%s/control/#", device->device_topic);
+    snprintf(topic, TOPIC_LENGTH, "%s/control/consumer/properties", device->device_topic);
     ESP_LOGI(TAG, "Subscribing to %s", topic);
     esp_mqtt_client_subscribe(mqtt, topic, 2);
 
-    char *interface_name_begin = device->introspection_string;
-    char *interface_name_end = strchr(device->introspection_string, ':');
-    int interface_name_len = interface_name_end - interface_name_begin;
-    while (interface_name_begin != NULL) {
-        // Subscribe to interface root topic
-        snprintf(topic, TOPIC_LENGTH, "%s/%.*s", device->device_topic, interface_name_len,
-            interface_name_begin);
-        ESP_LOGI(TAG, "Subscribing to %s", topic);
-        esp_mqtt_client_subscribe(mqtt, topic, 2);
-
-        // Subscribe to all interface subtopics
-        snprintf(topic, TOPIC_LENGTH, "%s/%.*s/#", device->device_topic, interface_name_len,
-            interface_name_begin);
-        ESP_LOGI(TAG, "Subscribing to %s", topic);
-        esp_mqtt_client_subscribe(mqtt, topic, 2);
-
-        interface_name_begin = strchr(interface_name_begin, ';');
-        if (!interface_name_begin) {
-            break;
+    struct astarte_list_head_t *item;
+    LIST_FOR_EACH(item, &device->interfaces_list)
+    {
+        struct astarte_ptr_list_entry_t *entry
+            = GET_LIST_ENTRY(item, struct astarte_ptr_list_entry_t, head);
+        const astarte_interface_t *interface = entry->value;
+        if (interface->ownership == OWNERSHIP_SERVER) {
+            // Subscribe to server interface subtopics
+            snprintf(topic, TOPIC_LENGTH, "%s/%s/#", device->device_topic, interface->name);
+            ESP_LOGI(TAG, "Subscribing to %s", topic);
+            esp_mqtt_client_subscribe(mqtt, topic, 2);
         }
-        // interface_name begins the character after ;
-        ++interface_name_begin;
-        interface_name_end = strchr(interface_name_begin, ':');
-        interface_name_len = interface_name_end - interface_name_begin;
     }
 }
 

--- a/examples/toggle_led/main/app_main.c
+++ b/examples/toggle_led/main/app_main.c
@@ -1,3 +1,4 @@
+#include "astarte_interface.h"
 #include "esp_event_loop.h"
 #include "esp_wifi.h"
 #include "nvs_flash.h"
@@ -30,6 +31,22 @@
 static EventGroupHandle_t wifi_event_group;
 const static int CONNECTED_BIT = BIT0;
 static xQueueHandle button_evt_queue;
+
+const static astarte_interface_t device_datastream_interface = {
+    .name = "org.astarteplatform.esp32.DeviceDatastream",
+    .major_version = 0,
+    .minor_version = 1,
+    .ownership = OWNERSHIP_DEVICE,
+    .type = TYPE_DATASTREAM,
+};
+
+const static astarte_interface_t server_datastream_interface = {
+    .name = "org.astarteplatform.esp32.ServerDatastream",
+    .major_version = 0,
+    .minor_version = 1,
+    .ownership = OWNERSHIP_SERVER,
+    .type = TYPE_DATASTREAM,
+};
 
 static esp_err_t wifi_event_handler(void *ctx, system_event_t *event)
 {
@@ -153,8 +170,8 @@ static void astarte_example_task(void *ctx)
         return;
     }
 
-    astarte_device_add_interface(device, "org.astarteplatform.esp32.DeviceDatastream", 0, 2);
-    astarte_device_add_interface(device, "org.astarteplatform.esp32.ServerDatastream", 0, 1);
+    astarte_device_add_interface(device, &device_datastream_interface);
+    astarte_device_add_interface(device, &server_datastream_interface);
     if (astarte_device_start(device) != ASTARTE_OK) {
         ESP_LOGE(TAG, "Failed to start astarte device");
         return;

--- a/include/astarte_device.h
+++ b/include/astarte_device.h
@@ -14,6 +14,8 @@
 
 #include "astarte.h"
 
+#include <astarte_interface.h>
+
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -112,13 +114,13 @@ void astarte_device_destroy(astarte_device_handle_t device);
  * @details This function has to be called before astarte_device_start to add all the needed Astarte
  * interfaces, that will be sent in the device introspection when it connects.
  * @param device A valid Astarte device handle.
- * @param interface_name A string containing the name of the interface.
- * @param major_version The major version of the interface.
- * @param minor_version The minor_version of the interface.
+ * @param interface A pointer to an astarte_interface_t struct describing the interface. The caller
+ * is responsible for making sure the pointed interface remains valid for the lifetime of the
+ * astarte_device. It is recommended to declare interface structs as static const.
  * @return ASTARTE_OK if the interface was succesfully added, another astarte_err_t otherwise.
  */
-astarte_err_t astarte_device_add_interface(astarte_device_handle_t device,
-    const char *interface_name, int major_version, int minor_version);
+astarte_err_t astarte_device_add_interface(
+    astarte_device_handle_t device, const astarte_interface_t *interface);
 
 /**
  * @brief start Astarte device.

--- a/include/astarte_interface.h
+++ b/include/astarte_interface.h
@@ -1,0 +1,48 @@
+/*
+ * (C) Copyright 2021, Ispirata Srl, info@ispirata.com.
+ *
+ * SPDX-License-Identifier: LGPL-2.1+ OR Apache-2.0
+ */
+
+/**
+ * @file astarte_interface.h
+ * @brief Astarte interface functions.
+ */
+
+#ifndef _ASTARTE_INTERFACE_H_
+#define _ASTARTE_INTERFACE_H_
+
+/**
+ * @brief interface ownership
+ *
+ * This enum represents the possible ownerhips of an Astarte interface
+ */
+typedef enum
+{
+    OWNERSHIP_DEVICE = 1, /**< Device owned interface */
+    OWNERSHIP_SERVER, /**< Server owned interface*/
+} astarte_interface_ownership_t;
+
+typedef enum
+{
+    TYPE_DATASTREAM = 1, /**< Datastream interface */
+    TYPE_PROPERTIES, /**< Properties interface */
+} astarte_interface_type_t;
+
+/**
+ * @brief Astarte interface definition
+ *
+ * This struct represents a subset of the information contained in an Astarte interface, and can be
+ * used to specify some details about a specific interface.
+ *
+ */
+typedef struct
+{
+    const char *name; /**< Interface name */
+    int major_version; /**< Major version */
+    int minor_version; /**< Minor version */
+    astarte_interface_ownership_t ownership; /**< Ownership, see #astarte_interface_ownership_t */
+    astarte_interface_type_t type; /**< Type, see #astarte_interface_type_t */
+} astarte_interface_t;
+
+#endif

--- a/include/astarte_list.h
+++ b/include/astarte_list.h
@@ -1,0 +1,156 @@
+/*
+ * (C) Copyright 2018, Davide Bettio, davide@uninstall.it.
+ *
+ * SPDX-License-Identifier: LGPL-2.1+ OR Apache-2.0
+ */
+
+#ifndef _ASTARTE_LIST_H_
+#define _ASTARTE_LIST_H_
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+struct astarte_list_head_t
+{
+    struct astarte_list_head_t *next;
+    struct astarte_list_head_t *prev;
+};
+
+struct astarte_ptr_list_entry_t
+{
+    struct astarte_list_head_t head;
+    const void *value;
+};
+
+/**
+ * @brief gets a pointer to the struct that contains a certain list head
+ *
+ * @details This macro should be used to retrieve a pointer to the struct that is containing the
+ * given ListHead.
+ */
+#define GET_LIST_ENTRY(list_item, type, list_head_member)                                          \
+    ((type *) (((char *) (list_item)) - ((unsigned long) &((type *) 0)->list_head_member)))
+
+/**
+ * @brief iterates through the list
+ *
+ * @details This macro should be used to iterate through the linked list without modifying it
+ */
+#define LIST_FOR_EACH(item, head) for (item = (head)->next; item != (head); item = item->next)
+
+/**
+ * @brief iterates through the list, possibly modifying it
+ *
+ * @details This macro should be used to iterate through the linked list when there is the need
+ * to modify it while iterating
+ */
+#define MUTABLE_LIST_FOR_EACH(item, tmp, head)                                                     \
+    for (item = (head)->next, tmp = item->next; item != (head); item = tmp, tmp = item->next)
+
+/**
+ * @brief Inserts a linked list head between two linked list heads
+ *
+ * @details It inserts a linked list head between prev_head and next_head.
+ * @param new_item the linked list head that will be inserted to the linked list
+ * @param prev_head the linked list head that comes before the element that is going to be inserted
+ * @param next_head the linked list head that comes after the element that is going to be inserted
+ */
+static inline void astarte_list_insert(struct astarte_list_head_t *new_item,
+    struct astarte_list_head_t *prev_head, struct astarte_list_head_t *next_head)
+{
+    new_item->prev = prev_head;
+    new_item->next = next_head;
+    next_head->prev = new_item;
+    prev_head->next = new_item;
+}
+
+/**
+ * @brief Appends a list item to a linked list
+ *
+ * @details It appends a list item head to a linked list and it initializes linked list pointer if
+ * empty.
+ * @param list a pointer to the linked list pointer that the head is going to be append, it will be
+ * set to new_item if it is the first one
+ * @param new_item the item that is going to be appended to the end of the list
+ */
+static inline void astarte_list_append(
+    struct astarte_list_head_t *head, struct astarte_list_head_t *new_item)
+{
+    astarte_list_insert(new_item, head->prev, head);
+}
+
+/**
+ * @brief Prepends a list item to a linked list
+ *
+ * @details It prepends a list item head to a linked list and it updates the pointer to the list.
+ * @param list a pointer to the linked list
+ * @param new_item the list head that is going to be prepended to the list
+ */
+static inline void astarte_list_prepend(
+    struct astarte_list_head_t *head, struct astarte_list_head_t *new_item)
+{
+    astarte_list_insert(new_item, head, head->next);
+}
+
+/**
+ * @brief Removes a linked list item from a linked list
+ *
+ * @details It removes a linked list head from the list pointed by list.
+ * @param list a pointer to the linked list pointer that we want to remove the item from, it will be
+ * set to NULL if no items are left
+ * @param remove_item the item that is going to be removed
+ */
+static inline void astarte_list_remove(struct astarte_list_head_t *remove_item)
+{
+    remove_item->prev->next = remove_item->next;
+    remove_item->next->prev = remove_item->prev;
+}
+
+/**
+ * @brief Initializes a linked list
+ *
+ * @details This function must be called to initialized a newly created list
+ * @param head a pointer to the linked list
+ */
+static inline void astarte_list_init(struct astarte_list_head_t *head)
+{
+    head->prev = head;
+    head->next = head;
+}
+
+/**
+ * @brief Checks if the linked list is empty
+ *
+ * @details This function returns true if the linked list is empty
+ * @return true if the list is empty, false otherwise
+ */
+static inline bool astarte_list_is_empty(struct astarte_list_head_t *list_item)
+{
+    return (list_item->next == list_item) && (list_item->prev == list_item);
+}
+
+/**
+ * @brief Returns the first item of the list
+ *
+ * @details This function returns the first item of the linked list pointed by head
+ * @param head a pointer to the linked list
+ * @return A pointer to the first item of the list
+ */
+static inline struct astarte_list_head_t *astarte_list_first(struct astarte_list_head_t *head)
+{
+    return head->next;
+}
+
+/**
+ * @brief Returns the last item of the list
+ *
+ * @details This function returns the last item of the linked list pointed by head
+ * @param head a pointer to the linked list
+ * @return A pointer to the last item of the list
+ */
+static inline struct astarte_list_head_t *astarte_list_last(struct astarte_list_head_t *head)
+{
+    return head->prev;
+}
+
+#endif


### PR DESCRIPTION
Pass a pointer to an `astarte_interface_t` struct. This allows to cleanup subscriptions, subscribing only to server owned interfaces (see https://github.com/astarte-platform/astarte/issues/568).