### PR TITLE
Config realm at runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.0] - Unreleased
+### Added
+- Allow passing an explicit realm to `astarte_device_config_t`.
+
 ## [1.0.0-rc.0] - 2021-05-10
 ### Changed
 - `astarte_device_add_interface` **incompatible API change**, the caller now has to provide a

--- a/include/astarte_device.h
+++ b/include/astarte_device.h
@@ -60,6 +60,7 @@ typedef struct
     astarte_device_disconnection_event_callback_t disconnection_event_callback;
     const char *hwid;
     const char *credentials_secret;
+    const char *realm;
 } astarte_device_config_t;
 
 #ifdef __cplusplus


### PR DESCRIPTION
Allow passing an explicit realm to **astarte_device_config_t.**

Signed-off-by: Antonio Gisondi <antonio.gisondi@secomind.com>