### PR TITLE
Add uuid_generate_v4 function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.0.1] - Unreleased
 ### Added
 - Allow passing an explicit realm to `astarte_device_config_t`.
+- Add function for generating random UUIDv4.
 
 ## [1.0.0] - 2021-07-02
 

--- a/include/uuid.h
+++ b/include/uuid.h
@@ -24,7 +24,7 @@ extern "C" {
  * @param ns The UUID to be used as namespace.
  * @param data A pointer to the data that will be hashed to produce the UUID.
  * @param len The lenght of the data.
- * @param len The UUID where the result will be written.
+ * @param out The UUID where the result will be written.
  */
 void uuid_generate_v5(const uuid_t ns, const void *data, size_t len, uuid_t out);
 
@@ -46,6 +46,14 @@ void uuid_to_string(const uuid_t uuid, char *out);
  * @return 0 if the parsing was succesfull, -1 otherwise.
  */
 int uuid_from_string(const char *in, uuid_t uuid);
+
+/**
+ * @brief generate a UUIDv4.
+ *
+ * @details This function computes a random UUID using hardware RNG.
+ * @param out The UUID where the result will be written.
+ */
+void uuid_generate_v4(uuid_t out);
 
 #ifdef __cplusplus
 }

--- a/uuid.c
+++ b/uuid.c
@@ -7,6 +7,7 @@
 #include "uuid.h"
 
 #include <esp_log.h>
+#include <esp_system.h>
 
 #include <arpa/inet.h>
 #include <stdio.h>
@@ -162,4 +163,19 @@ int uuid_from_string(const char *in, uuid_t uuid)
 
     uuid_from_struct(&uuid_struct, uuid);
     return 0;
+}
+
+void uuid_generate_v4(uuid_t out)
+{
+    uint8_t random_result[16];
+    esp_fill_random(random_result, 16);
+
+    struct uuid random_uuid_struct;
+    uuid_to_struct(random_result, &random_uuid_struct);
+
+    int version = 4;
+    random_uuid_struct.time_hi_and_version &= 0x0FFF;
+    random_uuid_struct.time_hi_and_version |= (version << 12);
+
+    uuid_from_struct(&random_uuid_struct, out);
 }


### PR DESCRIPTION
Add uuid_generate_v4 function.
    
Generate a random UUIDv4 using esp_fill_random function that makes use of hardware random number generator.
See [esp_fill_random](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/random.html#_CPPv415esp_fill_randomPv6size_t).

Signed-off-by: Antonio Gisondi <antonio.gisondi@secomind.com>