### PR TITLE
Add support to arrays for datastreams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Allow passing an explicit realm to `astarte_device_config_t`.
 - Add function for generating random UUIDv4.
+- Add astarte_bson_serializer_append_<T>_array functions to BSON serializer (for each supported
+  type).
+- Add astarte_device_stream_<T>_array(_with_timestamp) functions to astarte_device (for each
+  supported type) in order to enable sending arrays to array typed datastreams.
 
 ## [1.0.0] - 2021-07-02
 

--- a/include/astarte_bson_serializer.h
+++ b/include/astarte_bson_serializer.h
@@ -138,7 +138,7 @@ void astarte_bson_serializer_append_int64(
  * @param binary blob size in bytes.
  */
 void astarte_bson_serializer_append_binary(
-    struct astarte_bson_serializer_t *bs, const char *name, void *value, int size);
+    struct astarte_bson_serializer_t *bs, const char *name, const void *value, int size);
 
 /**
  * @brief append an UTF-8 string
@@ -188,6 +188,99 @@ void astarte_bson_serializer_append_boolean(
  */
 void astarte_bson_serializer_append_document(
     struct astarte_bson_serializer_t *bs, const char *name, const void *document);
+
+/**
+ * @brief append a double array
+ *
+ * @details This function appends a double array to the document. Stored value can be fetched using
+ * given key.
+ * @param bs a astarte_bson_serializer_t.
+ * @param name BSON key, which is a C string.
+ * @param double_array an array of doubles.
+ * @param count the number of items stored in double_array.
+ */
+void astarte_bson_serializer_append_double_array(
+    struct astarte_bson_serializer_t *bs, const char *name, const double *double_array, int count);
+
+/**
+ * @brief append an int32 array
+ *
+ * @details This function appends an int32 array to the document. Stored value can be fetched using
+ * given key.
+ * @param bs a astarte_bson_serializer_t.
+ * @param name BSON key, which is a C string.
+ * @param int32_array an array of signed 32 bit integers.
+ * @param count the number of items stored in int32_array.
+ */
+void astarte_bson_serializer_append_int32_array(
+    struct astarte_bson_serializer_t *bs, const char *name, const int32_t *int32_array, int count);
+
+/**
+ * @brief append an int64 array
+ *
+ * @details This function appends an int64 array to the document. Stored value can be fetched using
+ * given key.
+ * @param bs a astarte_bson_serializer_t.
+ * @param name BSON key, which is a C string.
+ * @param int64_array an array of signed 64 bit integers.
+ * @param count the number of items stored in int64_array.
+ */
+void astarte_bson_serializer_append_int64_array(
+    struct astarte_bson_serializer_t *bs, const char *name, const int64_t *int64_array, int count);
+
+/**
+ * @brief append a string array
+ *
+ * @details This function appends a string array to the document. Stored value can be fetched using
+ * given key.
+ * @param bs a astarte_bson_serializer_t.
+ * @param name BSON key, which is a C string.
+ * @param string_array an array of 0 terminated UTF-8 strings.
+ * @param count the number of items stored in string_array.
+ */
+void astarte_bson_serializer_append_string_array(struct astarte_bson_serializer_t *bs,
+    const char *name, const char *const *string_array, int count);
+
+/**
+ * @brief append a binary blob array
+ *
+ * @details This function appends a binary blob array to the document. Stored value can be fetched
+ * using given key.
+ * @param bs a astarte_bson_serializer_t.
+ * @param name BSON key, which is a C string.
+ * @param binarty_array an array of binary blobs (void *).
+ * @param sizes an array with the sizes of each binary in binary_array parameter.
+ * @param count the number of items stored in binary_array.
+ */
+void astarte_bson_serializer_append_binary_array(struct astarte_bson_serializer_t *bs,
+    const char *name, const void *const *binary_array, const int *sizes, int count);
+
+/**
+ * @brief append a date time array
+ *
+ * @details This function appends a date time array to the document. Stored value can be fetched
+ * using given key.
+ * @param bs a astarte_bson_serializer_t.
+ * @param name BSON key, which is a C string.
+ * @param epoch_millis_array an array of 64 bits unsigned integer storing date time in milliseconds
+ * since epoch.
+ * @param count the number of items stored in epoch_millis_array.
+ */
+void astarte_bson_serializer_append_datetime_array(struct astarte_bson_serializer_t *bs,
+    const char *name, const int64_t *epoch_millis_array, int count);
+
+/**
+ * @brief append a boolean array
+ *
+ * @details This function appends a boolean array to the document. Stored value can be fetched using
+ * given key.
+ * @param bs a astarte_bson_serializer_t.
+ * @param name BSON key, which is a C string.
+ * @param boolean_array an array of stdbool booleans.
+ * @param count the number of items stored in boolean_array.
+ */
+void astarte_bson_serializer_append_boolean_array(
+    struct astarte_bson_serializer_t *bs, const char *name, const bool *boolean_array, int count);
 
 #ifdef __cplusplus
 }

--- a/include/astarte_bson_types.h
+++ b/include/astarte_bson_types.h
@@ -17,6 +17,7 @@
 #define BSON_TYPE_DOUBLE    '\x01'
 #define BSON_TYPE_STRING    '\x02'
 #define BSON_TYPE_DOCUMENT  '\x03'
+#define BSON_TYPE_ARRAY     '\x04'
 #define BSON_TYPE_BINARY    '\x05'
 #define BSON_TYPE_BOOLEAN   '\x08'
 #define BSON_TYPE_DATETIME  '\x09'

--- a/include/astarte_device.h
+++ b/include/astarte_device.h
@@ -394,6 +394,316 @@ astarte_err_t astarte_device_stream_datetime_with_timestamp(astarte_device_handl
     const char *interface_name, const char *path, int64_t value, uint64_t ts_epoch_millis, int qos);
 
 /**
+ * @brief send a double array value on a datastream endpoint with an explicit timestamp.
+ *
+ * @details This function sends a double array value on a path of a given datastream interface.
+ * @param device A started Astarte device handle.
+ * @param interface_name A string containing the name of the interface.
+ * @param path A string containing the path (beginning with /).
+ * @param values The array of double to be sent.
+ * @param count The number of values stored in values array.
+ * @param ts_epoch_millis The timestamp of the datastream. This is useful only on mappings with
+ * explicit_timestamp set to true and it's represented as milliseconds since epoch. A value of
+ * ASTARTE_INVALID_TIMESTAMP is ignored.
+ * @param qos The MQTT QoS to be used for the publish (0, 1 or 2).
+ * @return ASTARTE_OK if the value was correctly published, another astarte_err_t otherwise. Note
+ * that this just checks that the publish sequence correctly started, i.e. it doesn't wait for
+ * PUBACK for QoS 1 messages or for PUBCOMP for QoS 2 messages
+ */
+astarte_err_t astarte_device_stream_double_array_with_timestamp(astarte_device_handle_t device,
+    const char *interface_name, const char *path, const double *values, int count,
+    uint64_t ts_epoch_millis, int qos);
+
+/**
+ * @brief send a double array value on a datastream endpoint.
+ *
+ * @details This function sends a double array value on a path of a given datastream interface.
+ * @param device A started Astarte device handle.
+ * @param interface_name A string containing the name of the interface.
+ * @param path A string containing the path (beginning with /).
+ * @param values The array of double to be sent.
+ * @param count The number of values stored in values array.
+ * @param qos The MQTT QoS to be used for the publish (0, 1 or 2).
+ * @return ASTARTE_OK if the value was correctly published, another astarte_err_t otherwise. Note
+ * that this just checks that the publish sequence correctly started, i.e. it doesn't wait for
+ * PUBACK for QoS 1 messages or for PUBCOMP for QoS 2 messages
+ */
+static inline astarte_err_t astarte_device_stream_double_array(astarte_device_handle_t device,
+    const char *interface_name, const char *path, const double *values, int count,
+    uint64_t ts_epoch_millis, int qos)
+{
+    return astarte_device_stream_double_array_with_timestamp(
+        device, interface_name, path, values, count, ASTARTE_INVALID_TIMESTAMP, qos);
+}
+
+/**
+ * @brief send a 32 bit integer array value on a datastream endpoint with an explicit timestamp.
+ *
+ * @details This function sends a signed 32 bit int array value on a path of a given datastream
+ * interface.
+ * @param device A started Astarte device handle.
+ * @param interface_name A string containing the name of the interface.
+ * @param path A string containing the path (beginning with /).
+ * @param values The array of int32_t to be sent.
+ * @param count The number of values stored in values array.
+ * @param ts_epoch_millis The timestamp of the datastream. This is useful only on mappings with
+ * explicit_timestamp set to true and it's represented as milliseconds since epoch. A value of
+ * ASTARTE_INVALID_TIMESTAMP is ignored.
+ * @param qos The MQTT QoS to be used for the publish (0, 1 or 2).
+ * @return ASTARTE_OK if the value was correctly published, another astarte_err_t otherwise. Note
+ * that this just checks that the publish sequence correctly started, i.e. it doesn't wait for
+ * PUBACK for QoS 1 messages or for PUBCOMP for QoS 2 messages
+ */
+astarte_err_t astarte_device_stream_integer_array_with_timestamp(astarte_device_handle_t device,
+    const char *interface_name, const char *path, const int32_t *values, int count,
+    uint64_t ts_epoch_millis, int qos);
+
+/**
+ * @brief send a 32 bit integer array value on a datastream endpoint.
+ *
+ * @details This function sends a signed 32 bit int array value on a path of a given datastream
+ * interface.
+ * @param device A started Astarte device handle.
+ * @param interface_name A string containing the name of the interface.
+ * @param path A string containing the path (beginning with /).
+ * @param values The array of int32_t to be sent.
+ * @param count The number of values stored in values array.
+ * @param qos The MQTT QoS to be used for the publish (0, 1 or 2).
+ * @return ASTARTE_OK if the value was correctly published, another astarte_err_t otherwise. Note
+ * that this just checks that the publish sequence correctly started, i.e. it doesn't wait for
+ * PUBACK for QoS 1 messages or for PUBCOMP for QoS 2 messages
+ */
+static inline astarte_err_t astarte_device_stream_integer_array(astarte_device_handle_t device,
+    const char *interface_name, const char *path, const int32_t *values, int count, int qos)
+{
+    return astarte_device_stream_integer_array_with_timestamp(
+        device, interface_name, path, values, count, ASTARTE_INVALID_TIMESTAMP, qos);
+}
+
+/**
+ * @brief send a 64 bit integer array value on a datastream endpoint with an explicit timestamp.
+ *
+ * @details This function sends a signed 64 bit int array value on a path of a given datastream
+ * interface.
+ * @param device A started Astarte device handle.
+ * @param interface_name A string containing the name of the interface.
+ * @param path A string containing the path (beginning with /).
+ * @param values The array of int64_t to be sent.
+ * @param count The number of values stored in values array.
+ * @param ts_epoch_millis The timestamp of the datastream. This is useful only on mappings with
+ * explicit_timestamp set to true and it's represented as milliseconds since epoch. A value of
+ * ASTARTE_INVALID_TIMESTAMP is ignored.
+ * @param qos The MQTT QoS to be used for the publish (0, 1 or 2).
+ * @return ASTARTE_OK if the value was correctly published, another astarte_err_t otherwise. Note
+ * that this just checks that the publish sequence correctly started, i.e. it doesn't wait for
+ * PUBACK for QoS 1 messages or for PUBCOMP for QoS 2 messages
+ */
+astarte_err_t astarte_device_stream_longinteger_array_with_timestamp(astarte_device_handle_t device,
+    const char *interface_name, const char *path, const int64_t *values, int count,
+    uint64_t ts_epoch_millis, int qos);
+
+/**
+ * @brief send a 64 bit integer array value on a datastream endpoint.
+ *
+ * @details This function sends a signed 64 bit int array value on a path of a given datastream
+ * interface.
+ * @param device A started Astarte device handle.
+ * @param interface_name A string containing the name of the interface.
+ * @param path A string containing the path (beginning with /).
+ * @param values The array of int64_t to be sent.
+ * @param count The number of values stored in values array.
+ * @param qos The MQTT QoS to be used for the publish (0, 1 or 2).
+ * @return ASTARTE_OK if the value was correctly published, another astarte_err_t otherwise. Note
+ * that this just checks that the publish sequence correctly started, i.e. it doesn't wait for
+ * PUBACK for QoS 1 messages or for PUBCOMP for QoS 2 messages
+ */
+static inline astarte_err_t astarte_device_stream_longinteger_array(astarte_device_handle_t device,
+    const char *interface_name, const char *path, const int64_t *values, int count, int qos)
+{
+    return astarte_device_stream_longinteger_array_with_timestamp(
+        device, interface_name, path, values, count, ASTARTE_INVALID_TIMESTAMP, qos);
+}
+
+/**
+ * @brief send a boolean array value on a datastream endpoint with an explicit timestamp.
+ *
+ * @details This function sends a boolean array value on a path of a given datastream interface.
+ * @param device A started Astarte device handle.
+ * @param interface_name A string containing the name of the interface.
+ * @param path A string containing the path (beginning with /).
+ * @param values The array of booleans to be sent (false or true).
+ * @param count The number of values stored in values array.
+ * @param ts_epoch_millis The timestamp of the datastream. This is useful only on mappings with
+ * explicit_timestamp set to true and it's represented as milliseconds since epoch. A value of
+ * ASTARTE_INVALID_TIMESTAMP is ignored.
+ * @param qos The MQTT QoS to be used for the publish (0, 1 or 2).
+ * @return ASTARTE_OK if the value was correctly published, another astarte_err_t otherwise. Note
+ * that this just checks that the publish sequence correctly started, i.e. it doesn't wait for
+ * PUBACK for QoS 1 messages or for PUBCOMP for QoS 2 messages
+ */
+astarte_err_t astarte_device_stream_boolean_array_with_timestamp(astarte_device_handle_t device,
+    const char *interface_name, const char *path, const bool *values, int count,
+    uint64_t ts_epoch_millis, int qos);
+
+/**
+ * @brief send a boolean array value on a datastream endpoint.
+ *
+ * @details This function sends a boolean array value on a path of a given datastream interface.
+ * @param device A started Astarte device handle.
+ * @param interface_name A string containing the name of the interface.
+ * @param path A string containing the path (beginning with /).
+ * @param values The array of booleans to be sent (false or true).
+ * @param count The number of values stored in values array.
+ * @param qos The MQTT QoS to be used for the publish (0, 1 or 2).
+ * @return ASTARTE_OK if the value was correctly published, another astarte_err_t otherwise. Note
+ * that this just checks that the publish sequence correctly started, i.e. it doesn't wait for
+ * PUBACK for QoS 1 messages or for PUBCOMP for QoS 2 messages
+ */
+static inline astarte_err_t astarte_device_stream_boolean_array(astarte_device_handle_t device,
+    const char *interface_name, const char *path, const bool *values, int count, int qos)
+{
+    return astarte_device_stream_boolean_array_with_timestamp(
+        device, interface_name, path, values, count, ASTARTE_INVALID_TIMESTAMP, qos);
+}
+
+/**
+ * @brief send a string array value on a datastream endpoint with an explicit timestamp.
+ *
+ * @details This function sends a string array value on a path of a given datastream interface.
+ * @param device A started Astarte device handle.
+ * @param interface_name A string containing the name of the interface.
+ * @param path A string containing the path (beginning with /).
+ * @param values The array of C strings to be sent (having each one const char * type and encoded as
+ * 0 terminated UTF-8 string).
+ * @param count The number of values stored in values array.
+ * @param ts_epoch_millis The timestamp of the datastream. This is useful only on mappings with
+ * explicit_timestamp set to true and it's represented as milliseconds since epoch. A value of
+ * ASTARTE_INVALID_TIMESTAMP is ignored.
+ * @param qos The MQTT QoS to be used for the publish (0, 1 or 2).
+ * @return ASTARTE_OK if the value was correctly published, another astarte_err_t otherwise. Note
+ * that this just checks that the publish sequence correctly started, i.e. it doesn't wait for
+ * PUBACK for QoS 1 messages or for PUBCOMP for QoS 2 messages
+ */
+astarte_err_t astarte_device_stream_string_array_with_timestamp(astarte_device_handle_t device,
+    const char *interface_name, const char *path, const char *const *values, int count,
+    uint64_t ts_epoch_millis, int qos);
+
+/**
+ * @brief send a string array value on a datastream endpoint.
+ *
+ * @details This function sends a string array value on a path of a given datastream interface. The
+ * datetime represents the number of milliseconds since Unix epoch (1970-01-01).
+ * @param device A started Astarte device handle.
+ * @param interface_name A string containing the name of the interface.
+ * @param path A string containing the path (beginning with /).
+ * @param values The array of C strings to be sent (having each one const char * type and encoded as
+ * 0 terminated UTF-8 string).
+ * @param count The number of values stored in values array.
+ * @param qos The MQTT QoS to be used for the publish (0, 1 or 2).
+ * @return ASTARTE_OK if the value was correctly published, another astarte_err_t otherwise. Note
+ * that this just checks that the publish sequence correctly started, i.e. it doesn't wait for
+ * PUBACK for QoS 1 messages or for PUBCOMP for QoS 2 messages
+ */
+
+static inline astarte_err_t astarte_device_stream_string_array(astarte_device_handle_t device,
+    const char *interface_name, const char *path, const char **values, int count, int qos)
+{
+    return astarte_device_stream_string_array_with_timestamp(
+        device, interface_name, path, values, count, ASTARTE_INVALID_TIMESTAMP, qos);
+}
+
+/**
+ * @brief send a binary blob array value on a datastream endpoint with an explicit timestamp.
+ *
+ * @details This function sends a binary blob array value on a path of a given datastream interface.
+ * @param device A started Astarte device handle.
+ * @param interface_name A string containing the name of the interface.
+ * @param path A string containing the path (beginning with /).
+ * @param values The array of binary blobs to be sent (having each one const void * type).
+ * @param sizes The size of each binary blob that is in the given values array.
+ * @param count The number of values stored in values array.
+ * @param ts_epoch_millis The timestamp of the datastream. This is useful only on mappings with
+ * explicit_timestamp set to true and it's represented as milliseconds since epoch. A value of
+ * ASTARTE_INVALID_TIMESTAMP is ignored.
+ * @param qos The MQTT QoS to be used for the publish (0, 1 or 2).
+ * @return ASTARTE_OK if the value was correctly published, another astarte_err_t otherwise. Note
+ * that this just checks that the publish sequence correctly started, i.e. it doesn't wait for
+ * PUBACK for QoS 1 messages or for PUBCOMP for QoS 2 messages
+ */
+astarte_err_t astarte_device_stream_binaryblob_array_with_timestamp(astarte_device_handle_t device,
+    const char *interface_name, const char *path, const void *const *values, const int *sizes,
+    int count, uint64_t ts_epoch_millis, int qos);
+
+/**
+ * @brief send a binary blob array value on a datastream endpoint with an explicit timestamp.
+ *
+ * @details This function sends a binary blob array value on a path of a given datastream interface.
+ * @param device A started Astarte device handle.
+ * @param interface_name A string containing the name of the interface.
+ * @param path A string containing the path (beginning with /).
+ * @param values The array of binary blobs to be sent (having each one const void * type).
+ * @param sizes The size of each binary blob that is in the given values array.
+ * @param count The number of values stored in values array.
+ * @param qos The MQTT QoS to be used for the publish (0, 1 or 2).
+ * @return ASTARTE_OK if the value was correctly published, another astarte_err_t otherwise. Note
+ * that this just checks that the publish sequence correctly started, i.e. it doesn't wait for
+ * PUBACK for QoS 1 messages or for PUBCOMP for QoS 2 messages
+ */
+static inline astarte_err_t astarte_device_stream_binaryblob_array(astarte_device_handle_t device,
+    const char *interface_name, const char *path, const void *const *values, const int *sizes,
+    int count, int qos)
+{
+    return astarte_device_stream_binaryblob_array_with_timestamp(
+        device, interface_name, path, values, sizes, count, ASTARTE_INVALID_TIMESTAMP, qos);
+}
+
+/**
+ * @brief send a datetime value on a datastream endpoint with an explicit timestamp.
+ *
+ * @details This function sends a datetime value on a path of a given datastream interface. The
+ * datetime represents the number of milliseconds since Unix epoch (1970-01-01).
+ * @param device A started Astarte device handle.
+ * @param interface_name A string containing the name of the interface.
+ * @param path A string containing the path (beginning with /).
+ * @param values The array of datetimes, each one representing the number of milliseconds since Unix
+ * epoch (1970-01-01).
+ * @param count The number of values stored in values array.
+ * @param ts_epoch_millis The timestamp of the datastream. This is useful only on mappings with
+ * explicit_timestamp set to true and it's represented as milliseconds since epoch. A value of
+ * ASTARTE_INVALID_TIMESTAMP is ignored.
+ * @param qos The MQTT QoS to be used for the publish (0, 1 or 2).
+ * @return ASTARTE_OK if the value was correctly published, another astarte_err_t otherwise. Note
+ * that this just checks that the publish sequence correctly started, i.e. it doesn't wait for
+ * PUBACK for QoS 1 messages or for PUBCOMP for QoS 2 messages
+ */
+astarte_err_t astarte_device_stream_datetime_array_with_timestamp(astarte_device_handle_t device,
+    const char *interface_name, const char *path, const int64_t *values, int count,
+    uint64_t ts_epoch_millis, int qos);
+
+/**
+ * @brief send a datetime value on a datastream endpoint.
+ *
+ * @details This function sends a datetime value on a path of a given datastream interface. The
+ * datetime represents the number of milliseconds since Unix epoch (1970-01-01).
+ * @param device A started Astarte device handle.
+ * @param interface_name A string containing the name of the interface.
+ * @param path A string containing the path (beginning with /).
+ * @param values The array of datetimes, each one representing the number of milliseconds since Unix
+ * epoch (1970-01-01).
+ * @param count The number of values stored in values array.
+ * @param qos The MQTT QoS to be used for the publish (0, 1 or 2).
+ * @return ASTARTE_OK if the value was correctly published, another astarte_err_t otherwise. Note
+ * that this just checks that the publish sequence correctly started, i.e. it doesn't wait for
+ * PUBACK for QoS 1 messages or for PUBCOMP for QoS 2 messages
+ */
+static inline astarte_err_t astarte_device_stream_datetime_array(astarte_device_handle_t device,
+    const char *interface_name, const char *path, const int64_t *values, int count, int qos)
+{
+    return astarte_device_stream_datetime_array_with_timestamp(
+        device, interface_name, path, values, count, ASTARTE_INVALID_TIMESTAMP, qos);
+}
+
+/**
  * @brief send an aggregate value on a datastream endpoint of an interface with object aggregation.
  *
  * @details This function sends an aggregate value on a path of a given datastream interface. The


### PR DESCRIPTION
Add `astarte_bson_serializer_append_<T>_array` functions to BSON serializer and
`astarte_device_stream_<T>_array(_with_timestamp)` functions to astarte_device (for each supported
type) in order to enable sending arrays to array typed datastreams.