### PR TITLE
Add support to server-owned property unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - unreleased
+### Added
+- Add support to server-owned property unset
+
 ## [1.0.1] - 2021-12-23
 ### Added
 - Allow passing an explicit realm to `astarte_device_config_t`.

--- a/include/astarte_device.h
+++ b/include/astarte_device.h
@@ -33,6 +33,13 @@ typedef struct
     int bson_value_type;
 } astarte_device_data_event_t;
 
+typedef struct
+{
+    astarte_device_handle_t device;
+    const char *interface_name;
+    const char *path;
+} astarte_device_unset_event_t;
+
 typedef void (*astarte_device_data_event_callback_t)(astarte_device_data_event_t *event);
 
 typedef struct
@@ -53,9 +60,12 @@ typedef struct
 typedef void (*astarte_device_disconnection_event_callback_t)(
     astarte_device_disconnection_event_t *event);
 
+typedef void (*astarte_device_unset_event_callback_t)(astarte_device_unset_event_t *event);
+
 typedef struct
 {
     astarte_device_data_event_callback_t data_event_callback;
+    astarte_device_unset_event_callback_t unset_event_callback;
     astarte_device_connection_event_callback_t connection_event_callback;
     astarte_device_disconnection_event_callback_t disconnection_event_callback;
     const char *hwid;


### PR DESCRIPTION
Three possible ways were found to implement the previously unsupported feature of unsetting a property belonging to a server-owned interface.

The first was to send an `astarte_device_data_event_t` with a `NULL` `bson_data` to the `data_event_callback`.
Similarly, a possibility was to send to it an `astarte_device_data_event_t` with the `bson_type` set as a newly introduced `BSON_TYPE_NULL`.
Lastly, it was considered the introduction of a new optional  `astarte_device_data_event_callback_t` called `unset_data_event_callback` in charge of handling only unset property operations.

The first two cases were deemed unsafe as the new behavior could cause troubles to users that already employ the SDK and have defined a `device_data_event_callback_t` without checking the two fields.

The latter was found a safer choice as it was not going to alter previous behaviors of the SDK.

Close #81 

Signed-off-by: Francesco Vaiani <francesco.vaiani@secomind.com>