### PR TITLE
Add const qualifiers for all `char *` used with string types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Add support to server-owned property unset
 
+### Changed
+- Functions such as `astarte_device_set_string_property` should make use of `const char *`, instead
+  of `char *`.
+
 ## [1.0.1] - 2021-12-23
 ### Added
 - Allow passing an explicit realm to `astarte_device_config_t`.

--- a/astarte_device.c
+++ b/astarte_device.c
@@ -580,7 +580,8 @@ astarte_err_t astarte_device_stream_boolean_with_timestamp(astarte_device_handle
 }
 
 astarte_err_t astarte_device_stream_string_with_timestamp(astarte_device_handle_t device,
-    const char *interface_name, const char *path, char *value, uint64_t ts_epoch_millis, int qos)
+    const char *interface_name, const char *path, const char *value, uint64_t ts_epoch_millis,
+    int qos)
 {
     struct astarte_bson_serializer_t bs;
     astarte_bson_serializer_init(&bs);
@@ -710,7 +711,7 @@ astarte_err_t astarte_device_stream_boolean(astarte_device_handle_t device,
 }
 
 astarte_err_t astarte_device_stream_string(astarte_device_handle_t device,
-    const char *interface_name, const char *path, char *value, int qos)
+    const char *interface_name, const char *path, const char *value, int qos)
 {
     return astarte_device_stream_string_with_timestamp(
         device, interface_name, path, value, ASTARTE_INVALID_TIMESTAMP, qos);
@@ -762,7 +763,7 @@ astarte_err_t astarte_device_set_boolean_property(
 }
 
 astarte_err_t astarte_device_set_string_property(
-    astarte_device_handle_t device, const char *interface_name, const char *path, char *value)
+    astarte_device_handle_t device, const char *interface_name, const char *path, const char *value)
 {
     return astarte_device_stream_string(device, interface_name, path, value, 2);
 }

--- a/include/astarte_device.h
+++ b/include/astarte_device.h
@@ -305,7 +305,7 @@ astarte_err_t astarte_device_stream_boolean_with_timestamp(astarte_device_handle
  * PUBACK for QoS 1 messages or for PUBCOMP for QoS 2 messages
  */
 astarte_err_t astarte_device_stream_string(astarte_device_handle_t device,
-    const char *interface_name, const char *path, char *value, int qos);
+    const char *interface_name, const char *path, const char *value, int qos);
 
 /**
  * @brief send a UTF8 encoded string on a datastream endpoint with an explicit timestamp.
@@ -324,7 +324,8 @@ astarte_err_t astarte_device_stream_string(astarte_device_handle_t device,
  * PUBACK for QoS 1 messages or for PUBCOMP for QoS 2 messages
  */
 astarte_err_t astarte_device_stream_string_with_timestamp(astarte_device_handle_t device,
-    const char *interface_name, const char *path, char *value, uint64_t ts_epoch_millis, int qos);
+    const char *interface_name, const char *path, const char *value, uint64_t ts_epoch_millis,
+    int qos);
 
 /**
  * @brief send a binary value on a datastream endpoint.
@@ -616,7 +617,7 @@ astarte_err_t astarte_device_stream_string_array_with_timestamp(astarte_device_h
  */
 
 static inline astarte_err_t astarte_device_stream_string_array(astarte_device_handle_t device,
-    const char *interface_name, const char *path, const char **values, int count, int qos)
+    const char *interface_name, const char *path, const char *const *values, int count, int qos)
 {
     return astarte_device_stream_string_array_with_timestamp(
         device, interface_name, path, values, count, ASTARTE_INVALID_TIMESTAMP, qos);
@@ -844,8 +845,8 @@ astarte_err_t astarte_device_set_boolean_property(
  * that this just checks that the publish sequence correctly started, i.e. it doesn't wait for
  * PUBCOMP for QoS 2 messages
  */
-astarte_err_t astarte_device_set_string_property(
-    astarte_device_handle_t device, const char *interface_name, const char *path, char *value);
+astarte_err_t astarte_device_set_string_property(astarte_device_handle_t device,
+    const char *interface_name, const char *path, const char *value);
 
 /**
  * @brief send a binary value on a properties endpoint.


### PR DESCRIPTION
const qualifier was missing by mistake, add it to all string functions.