### PR TITLE
Avoid adding invalid interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.4] - Unreleased
+### Added
+- Add check that prevents sending an interface with both major and minor version set to 0
+
 ## [1.0.3] - 2022-07-05
 
 ## [1.0.2] - 2022-04-14

--- a/astarte_device.c
+++ b/astarte_device.c
@@ -403,6 +403,11 @@ astarte_err_t astarte_device_add_interface(
         return ASTARTE_ERR;
     }
 
+    if (interface->major_version == 0 && interface->minor_version == 0) {
+        ESP_LOGE(TAG, "Trying to add an interface with both major and minor version equal 0");
+        return ASTARTE_ERR_INVALID_INTERFACE_VERSION;
+    }
+
     struct astarte_ptr_list_entry_t *entry = calloc(1, sizeof(struct astarte_ptr_list_entry_t));
     if (!entry) {
         ESP_LOGE(TAG, "Out of memory %s: %d", __FILE__, __LINE__);

--- a/include/astarte.h
+++ b/include/astarte.h
@@ -45,7 +45,8 @@ enum astarte_err_t
     ASTARTE_ERR_INVALID_QOS = 16, /**< The QoS is not valid */
     ASTARTE_ERR_DEVICE_NOT_READY = 17, /**< Tried to perform an operation on a Device in a non-ready or initialized state */
     ASTARTE_ERR_PUBLISH = 18, /**< An error occurred while publishing data on MQTT */
-    ASTARTE_ERR_INVALID_INTROSPECTION = 19 /**< The introspection is not valid or empty */
+    ASTARTE_ERR_INVALID_INTROSPECTION = 19, /**< The introspection is not valid or empty */
+    ASTARTE_ERR_INVALID_INTERFACE_VERSION = 20 /**< The interface is not valid */
 };
 
 // clang-format on


### PR DESCRIPTION
Avoid adding an interface with major and minor version numbers at zero adding a check to return a specific error.

Close #94 

Signed-off-by: Francesco Vaiani <francesco.vaiani@secomind.com>