### PR TITLE
New examples

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,6 +44,7 @@ jobs:
         example:
         - "aggregates"
         - "datastreams"
+        - "encryption"
         - "non_volatile_storage"
         - "registration"
         - "toggle_led"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,6 +44,7 @@ jobs:
         example:
         - "aggregates"
         - "datastreams"
+        - "non_volatile_storage"
         - "registration"
         - "toggle_led"
         exclude:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,6 +44,7 @@ jobs:
         example:
         - "aggregates"
         - "datastreams"
+        - "registration"
         - "toggle_led"
         exclude:
           # Exclude make build with newer idf version, not supported

--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -53,6 +53,7 @@ jobs:
         example:
         - "aggregates"
         - "datastreams"
+        - "encryption"
         - "non_volatile_storage"
         - "registration"
         - "toggle_led"

--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -53,6 +53,7 @@ jobs:
         example:
         - "aggregates"
         - "datastreams"
+        - "registration"
         - "toggle_led"
     container: espressif/idf:release-v5.1
     steps:

--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -53,6 +53,7 @@ jobs:
         example:
         - "aggregates"
         - "datastreams"
+        - "non_volatile_storage"
         - "registration"
         - "toggle_led"
     container: espressif/idf:release-v5.1

--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ If you want to use NVS storage, add the
 astarte_credentials_use_nvs_storage(NVS_PARTITION);
 ```
 
+However, note that even when FAT32 is used, the device credential secret is always stored using
+the NVS library. This will require devices configured as using FAT32 to have two partitions,
+one using as name the macro `NVS_DEFAULT_PART_NAME` (NVS) and one named `astarte` (FAT32).
+
+### Re-flashing devices
+
 As a side effect of NVM usage, credentials will be preserved also between device flashes using
 `make` or `idf.py`.
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ However, note that even when FAT32 is used, the device credential secret is alwa
 the NVS library. This will require devices configured as using FAT32 to have two partitions,
 one using as name the macro `NVS_DEFAULT_PART_NAME` (NVS) and one named `astarte` (FAT32).
 
+Furthermore, if you whish to use flash encryption for your device the only supported option is
+NVS.
+
 ### Re-flashing devices
 
 As a side effect of NVM usage, credentials will be preserved also between device flashes using

--- a/examples/encryption/CMakeLists.txt
+++ b/examples/encryption/CMakeLists.txt
@@ -1,0 +1,27 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2023 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later OR Apache-2.0
+#
+
+cmake_minimum_required(VERSION 3.5)
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+
+set(EXTRA_COMPONENT_DIRS ${CMAKE_SOURCE_DIR}/../..)
+
+project(encryption)

--- a/examples/encryption/Makefile
+++ b/examples/encryption/Makefile
@@ -1,0 +1,24 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2023 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later OR Apache-2.0
+#
+
+PROJECT_NAME := encryption
+EXTRA_COMPONENT_DIRS += $(PROJECT_PATH)/../../../
+
+include $(IDF_PATH)/make/project.mk

--- a/examples/encryption/README.md
+++ b/examples/encryption/README.md
@@ -1,0 +1,37 @@
+<!---
+  Copyright 2023 SECO Mind Srl
+
+  SPDX-License-Identifier: LGPL-2.1-or-later OR Apache-2.0
+-->
+
+# Astarte encryption example
+
+This example will guide you through setting up a simple ESP32 application running the Astarte SDK
+configured to use an NVS partition for persistent storage and with flash encryption enabled.
+
+This example will assume you have already registered manually the device to your Astarte instance.
+If you whish to perform on board registration through a JWT token then check out the `registration`
+example.
+
+## Partition table
+
+The partition table is the same as the one used in the `non_volatile_storage` example.
+The only difference is that encrypted partitions are explicitly marked as such.
+
+## Enabling encryption
+
+Encryption is generally enabled through `idf.py menuconfig`. For this example we provide a
+`sdkconfig.defaults` containing a pre-set configuration for encryption. This configuration is
+specifically intended for development purposes. It is not safe and should not be used in
+production.
+
+## First flash of a previously unencrypted device
+
+Flashing to a previously unencrypted device is the same as flashing non encrypted data.
+Use the standard command `idf.py flash`.
+
+## Subsequent flashes of encrypted device
+
+Once a device has been flashed with encrypted firmware the standard `idf.py flash` command will
+not work for flashing firmware.
+The two commands `idf.py encrypted-app-flash` and `idf.py encrypted-flash` can be used instead.

--- a/examples/encryption/interfaces/org.astarteplatform.esp32.examples.DeviceDatastream.json
+++ b/examples/encryption/interfaces/org.astarteplatform.esp32.examples.DeviceDatastream.json
@@ -1,0 +1,13 @@
+{
+   "interface_name": "org.astarteplatform.esp32.examples.DeviceDatastream",
+   "version_major": 0,
+   "version_minor": 1,
+   "type": "datastream",
+   "ownership": "device",
+   "mappings": [
+       {
+           "endpoint": "/answer",
+           "type": "boolean"
+       }
+    ]
+}

--- a/examples/encryption/interfaces/org.astarteplatform.esp32.examples.DeviceDatastream.json.license
+++ b/examples/encryption/interfaces/org.astarteplatform.esp32.examples.DeviceDatastream.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 SECO Mind Srl
+
+SPDX-License-Identifier: LGPL-2.1-or-later OR Apache-2.0

--- a/examples/encryption/interfaces/org.astarteplatform.esp32.examples.ServerDatastream.json
+++ b/examples/encryption/interfaces/org.astarteplatform.esp32.examples.ServerDatastream.json
@@ -1,0 +1,13 @@
+{
+   "interface_name": "org.astarteplatform.esp32.examples.ServerDatastream",
+   "version_major": 0,
+   "version_minor": 1,
+   "type": "datastream",
+   "ownership": "server",
+   "mappings": [
+       {
+           "endpoint": "/question",
+           "type": "boolean"
+       }
+    ]
+}

--- a/examples/encryption/interfaces/org.astarteplatform.esp32.examples.ServerDatastream.json.license
+++ b/examples/encryption/interfaces/org.astarteplatform.esp32.examples.ServerDatastream.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 SECO Mind Srl
+
+SPDX-License-Identifier: LGPL-2.1-or-later OR Apache-2.0

--- a/examples/encryption/main/CMakeLists.txt
+++ b/examples/encryption/main/CMakeLists.txt
@@ -1,0 +1,27 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2023 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later OR Apache-2.0
+#
+
+idf_component_register(
+    SRCS
+        "app_main.c"
+        "./src/wifi_cfg.c"
+        "./src/example_task.c"
+    INCLUDE_DIRS "./include"
+    REQUIRES astarte-device-sdk-esp32 nvs_flash esp_event esp_wifi)

--- a/examples/encryption/main/Kconfig.projbuild
+++ b/examples/encryption/main/Kconfig.projbuild
@@ -1,0 +1,47 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2023 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later OR Apache-2.0
+#
+
+menu "Astarte non volatile storage example"
+
+config WIFI_SSID
+    string "WiFi SSID"
+    default "myssid"
+    help
+        SSID (network name) for the example to connect to.
+
+config WIFI_PASSWORD
+    string "WiFi Password"
+    default "mypassword"
+    help
+        WiFi password (WPA or WPA2) for the example to use.
+
+config CREDENTIALS_SECRET
+    string "Credentials secret"
+    default ""
+    help
+        Astarte device credential secret, generated when the device is added on an Astarte instance.
+
+config DEVICE_ID
+    string "Device hardware ID"
+    default ""
+    help
+        Astarte device hardware id, generated when the device is added on an Astarte instance.
+
+endmenu

--- a/examples/encryption/main/app_main.c
+++ b/examples/encryption/main/app_main.c
@@ -1,0 +1,57 @@
+/**
+ * This file is part of Astarte.
+ *
+ * Copyright 2023 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR Apache-2.0
+ *
+ **/
+
+#include <esp_idf_version.h>
+#include <esp_log.h>
+#include <inttypes.h>
+#include <nvs_flash.h>
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/event_groups.h"
+#include "freertos/queue.h"
+#include "freertos/task.h"
+
+#include "example_task.h"
+#include "wifi_cfg.h"
+
+/************************************************
+ * Constants/Defines
+ ***********************************************/
+
+#define TAG "NVS_EXAMPLE_APP_MAIN"
+
+/************************************************
+ * Main function definition
+ ***********************************************/
+
+void app_main()
+{
+    ESP_LOGI(TAG, "Startup..");
+    ESP_LOGI(TAG, "Free memory: %" PRIu32 " bytes", esp_get_free_heap_size());
+    ESP_LOGI(TAG, "IDF version: %s", esp_get_idf_version());
+
+    esp_log_level_set("*", ESP_LOG_INFO);
+
+    nvs_flash_init();
+    wifi_init();
+
+    xTaskCreate(astarte_example_task, "astarte_example_task", 6000, NULL, tskIDLE_PRIORITY, NULL);
+}

--- a/examples/encryption/main/component.mk
+++ b/examples/encryption/main/component.mk
@@ -1,0 +1,22 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2023 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later OR Apache-2.0
+#
+
+COMPONENT_ADD_INCLUDEDIRS += include
+COMPONENT_SRCDIRS += src

--- a/examples/encryption/main/include/example_task.h
+++ b/examples/encryption/main/include/example_task.h
@@ -1,0 +1,32 @@
+/**
+ * This file is part of Astarte.
+ *
+ * Copyright 2023 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR Apache-2.0
+ *
+ **/
+
+#ifndef EXAMPLE_TASK_H
+#define EXAMPLE_TASK_H
+
+/**
+ * @brief Astarte configuration task.
+ *
+ * @param ctx ESP 32 task context.
+ */
+void astarte_example_task(void *ctx);
+
+#endif /* EXAMPLE_TASK_H */

--- a/examples/encryption/main/include/wifi_cfg.h
+++ b/examples/encryption/main/include/wifi_cfg.h
@@ -1,0 +1,30 @@
+/**
+ * This file is part of Astarte.
+ *
+ * Copyright 2023 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR Apache-2.0
+ *
+ **/
+
+#ifndef WIFI_CFG_H
+#define WIFI_CFG_H
+
+/**
+ * @brief Wifi module initialization function.
+ */
+void wifi_init(void);
+
+#endif /* WIFI_CFG_H */

--- a/examples/encryption/main/src/example_task.c
+++ b/examples/encryption/main/src/example_task.c
@@ -1,0 +1,198 @@
+/**
+ * This file is part of Astarte.
+ *
+ * Copyright 2023 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR Apache-2.0
+ *
+ **/
+
+#include "example_task.h"
+
+#include <esp_idf_version.h>
+#include <esp_log.h>
+#include <nvs_flash.h>
+
+#include "astarte.h"
+#include "astarte_bson_types.h"
+#include "astarte_credentials.h"
+#include "astarte_device.h"
+#include "astarte_interface.h"
+
+/************************************************
+ * Constants and defines
+ ***********************************************/
+
+#define TAG "NVS_EXAMPLE_EXAMPLE_TASK"
+
+static const char cred_sec[] = CONFIG_CREDENTIALS_SECRET;
+static const char hwid[] = CONFIG_DEVICE_ID;
+static const char realm[] = CONFIG_ASTARTE_REALM;
+
+const static astarte_interface_t device_datastream_interface = {
+    .name = "org.astarteplatform.esp32.examples.DeviceDatastream",
+    .major_version = 0,
+    .minor_version = 1,
+    .ownership = OWNERSHIP_DEVICE,
+    .type = TYPE_DATASTREAM,
+};
+
+const static astarte_interface_t server_datastream_interface = {
+    .name = "org.astarteplatform.esp32.examples.ServerDatastream",
+    .major_version = 0,
+    .minor_version = 1,
+    .ownership = OWNERSHIP_SERVER,
+    .type = TYPE_DATASTREAM,
+};
+
+/************************************************
+ * Static functions declaration
+ ***********************************************/
+
+/**
+ * @brief Handler for astarte connection events.
+ *
+ * @param event Astarte device connection event pointer.
+ */
+static void astarte_connection_events_handler(astarte_device_connection_event_t *event);
+/**
+ * @brief Handler for astarte data event.
+ *
+ * @param event Astarte device data event pointer.
+ */
+static void astarte_data_events_handler(astarte_device_data_event_t *event);
+/**
+ * @brief Handler for astarte disconnection events.
+ *
+ * @param event Astarte device disconnection event pointer.
+ */
+static void astarte_disconnection_events_handler(astarte_device_disconnection_event_t *event);
+/**
+ * @brief Initialize a custom NVS partition.
+ *
+ * @param name Name of the custom partition to initialize.
+ * @return ESP_OK if successful, an appropriate error code otherwise.
+ */
+static esp_err_t custom_nvs_part_init(const char *name);
+/************************************************
+ * Global functions definition
+ ***********************************************/
+
+void astarte_example_task(void *ctx)
+{
+    (void) ctx;
+
+    // Can be used to erase the partition when running the example multiple times on the same
+    // hardware but different hardware IDs.
+    // ESP_ERROR_CHECK(nvs_flash_erase_partition("astarte"));
+    esp_err_t ret = custom_nvs_part_init("astarte");
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to initialize astarte partition (%s)", esp_err_to_name(ret));
+        return;
+    }
+    astarte_credentials_use_nvs_storage("astarte");
+
+    if (astarte_credentials_init() != ASTARTE_OK) {
+        ESP_LOGE(TAG, "Failed to initialize credentials");
+        return;
+    }
+    astarte_device_config_t cfg = {
+        .data_event_callback = astarte_data_events_handler,
+        .connection_event_callback = astarte_connection_events_handler,
+        .disconnection_event_callback = astarte_disconnection_events_handler,
+        .credentials_secret = cred_sec,
+        .hwid = hwid,
+        .realm = realm,
+    };
+
+    astarte_device_handle_t device = astarte_device_init(&cfg);
+    if (!device) {
+        ESP_LOGE(TAG, "Failed to init astarte device");
+        return;
+    }
+
+    astarte_device_add_interface(device, &device_datastream_interface);
+    astarte_device_add_interface(device, &server_datastream_interface);
+    if (astarte_device_start(device) != ASTARTE_OK) {
+        ESP_LOGE(TAG, "Failed to start astarte device");
+        return;
+    }
+
+    ESP_LOGI(TAG, "Encoded device ID: %s", astarte_device_get_encoded_id(device));
+    while (1) {
+    }
+}
+
+/************************************************
+ * Static functions definitions
+ ***********************************************/
+
+static void astarte_connection_events_handler(astarte_device_connection_event_t *event)
+{
+    ESP_LOGI(TAG, "Astarte device connected, session_present: %d", event->session_present);
+}
+
+static void astarte_data_events_handler(astarte_device_data_event_t *event)
+{
+    ESP_LOGI(TAG, "Got Astarte data event, interface_name: %s, path: %s, bson_type: %d",
+        event->interface_name, event->path, event->bson_element.type);
+
+    if (strcmp(event->interface_name, "org.astarteplatform.esp32.examples.ServerDatastream") == 0
+        && strcmp(event->path, "/question") == 0 && event->bson_element.type == BSON_TYPE_BOOLEAN) {
+        bool answer = !astarte_bson_deserializer_element_to_bool(event->bson_element);
+        ESP_LOGI(TAG, "Sending answer %d.", answer);
+        astarte_device_stream_boolean(event->device,
+            "org.astarteplatform.esp32.examples.DeviceDatastream", "/answer", answer, 0);
+    }
+}
+
+static void astarte_disconnection_events_handler(astarte_device_disconnection_event_t *event)
+{
+    (void) event;
+
+    ESP_LOGI(TAG, "Astarte device disconnected");
+}
+
+static esp_err_t custom_nvs_part_init(const char *name)
+{
+#if CONFIG_NVS_ENCRYPTION
+    esp_err_t ret = ESP_FAIL;
+    const esp_partition_t *key_part = esp_partition_find_first(
+        ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_DATA_NVS_KEYS, NULL);
+    if (key_part == NULL) {
+        ESP_LOGE(TAG,
+            "CONFIG_NVS_ENCRYPTION is enabled, but no partition with subtype nvs_keys found in the "
+            "partition table.");
+        return ret;
+    }
+
+    nvs_sec_cfg_t cfg = {};
+    ret = nvs_flash_read_security_cfg(key_part, &cfg);
+    if (ret != ESP_OK) {
+        /* We shall not generate keys here as that must have been done in default NVS partition
+         * initialization case */
+        ESP_LOGE(TAG, "Failed to read NVS security cfg: [0x%02X] (%s)", ret, esp_err_to_name(ret));
+        return ret;
+    }
+
+    ret = nvs_flash_secure_init_partition(name, &cfg);
+    if (ret == ESP_OK) {
+        ESP_LOGI(TAG, "NVS partition \"%s\" is encrypted.", name);
+    }
+    return ret;
+#else
+    return nvs_flash_init_partition(name);
+#endif
+}

--- a/examples/encryption/main/src/wifi_cfg.c
+++ b/examples/encryption/main/src/wifi_cfg.c
@@ -1,0 +1,113 @@
+/**
+ * This file is part of Astarte.
+ *
+ * Copyright 2023 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR Apache-2.0
+ *
+ **/
+
+#include "wifi_cfg.h"
+
+#include <esp_idf_version.h>
+#include <esp_log.h>
+#include <esp_wifi.h>
+
+#include "freertos/event_groups.h"
+#include "freertos/task.h"
+
+/************************************************
+ * Constants/Defines
+ ***********************************************/
+
+#define TAG "NVS_EXAMPLE_WIFI_CFG"
+
+static EventGroupHandle_t wifi_event_group;
+const static int connected_bit = BIT0;
+
+/************************************************
+ * Static functions declaration
+ ***********************************************/
+
+/**
+ * @brief Wifi event handler for the ESP32 wifi.
+ *
+ * @details To be installed in an event loop.
+ * @param arg Remaining handler arguments.
+ * @param event_base event base.
+ * @param event_id event identifier.
+ * @param event_data event data.
+ * @return The status code, ASTARTE_OK if successful, otherwise an error code is returned.
+ */
+static void wifi_event_handler(
+    void *arg, esp_event_base_t event_base, int32_t event_id, void *event_data);
+
+/************************************************
+ * Global functions definition
+ ***********************************************/
+
+void wifi_init(void)
+{
+    wifi_event_group = xEventGroupCreate();
+
+    ESP_ERROR_CHECK(esp_netif_init());
+
+    ESP_ERROR_CHECK(esp_event_loop_create_default());
+    esp_netif_create_default_wifi_sta();
+
+    wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
+    ESP_ERROR_CHECK(esp_wifi_init(&cfg));
+
+    esp_event_handler_instance_t instance_any_id = NULL;
+    esp_event_handler_instance_t instance_got_ip = NULL;
+    ESP_ERROR_CHECK(esp_event_handler_instance_register(
+        WIFI_EVENT, ESP_EVENT_ANY_ID, &wifi_event_handler, NULL, &instance_any_id));
+    ESP_ERROR_CHECK(esp_event_handler_instance_register(
+        IP_EVENT, IP_EVENT_STA_GOT_IP, &wifi_event_handler, NULL, &instance_got_ip));
+
+    ESP_ERROR_CHECK(esp_wifi_set_storage(WIFI_STORAGE_RAM));
+    wifi_config_t wifi_config = {
+        .sta = {
+            .ssid = CONFIG_WIFI_SSID,
+            .password = CONFIG_WIFI_PASSWORD,
+        },
+    };
+    ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
+    ESP_ERROR_CHECK(esp_wifi_set_config(ESP_IF_WIFI_STA, &wifi_config));
+    ESP_LOGI(TAG, "start the WIFI SSID:[%s] password:[%s]", CONFIG_WIFI_SSID, "******");
+    ESP_ERROR_CHECK(esp_wifi_start());
+    ESP_LOGI(TAG, "Waiting for wifi");
+    xEventGroupWaitBits(wifi_event_group, connected_bit, false, true, portMAX_DELAY);
+}
+
+/************************************************
+ * Static functions definitions
+ ***********************************************/
+
+static void wifi_event_handler(
+    void *arg, esp_event_base_t event_base, int32_t event_id, void *event_data)
+{
+    (void) arg;
+    (void) event_data;
+
+    if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_START) {
+        esp_wifi_connect();
+    } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_DISCONNECTED) {
+        esp_wifi_connect();
+        xEventGroupClearBits(wifi_event_group, connected_bit);
+    } else if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP) {
+        xEventGroupSetBits(wifi_event_group, connected_bit);
+    }
+}

--- a/examples/encryption/partitions_example.csv
+++ b/examples/encryption/partitions_example.csv
@@ -1,0 +1,25 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2023 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later OR Apache-2.0
+#
+
+# Name,   Type, SubType, Offset,  Size, Flags
+nvs_key,  data, nvs_keys,,        0x1000, encrypted,
+nvs,      data, nvs,     ,        0x6000,
+factory,  app,  factory, ,        1500K, encrypted,
+astarte,  data, nvs,     ,        0x3000,

--- a/examples/encryption/sdkconfig.defaults
+++ b/examples/encryption/sdkconfig.defaults
@@ -1,0 +1,79 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2023 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later OR Apache-2.0
+#
+
+CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y
+
+#
+# Astarte SDK
+#
+CONFIG_ASTARTE_REALM=""
+CONFIG_ASTARTE_PAIRING_BASE_URL=""
+CONFIG_ASTARTE_HWID_ENABLE_UUID=n
+CONFIG_ASTARTE_HWID_UUID_NAMESPACE=""
+# end of Astarte SDK
+
+#
+# Astarte registration example
+#
+CONFIG_WIFI_SSID=""
+CONFIG_WIFI_PASSWORD=""
+CONFIG_CREDENTIALS_SECRET=""
+CONFIG_DEVICE_ID=""
+# end of Astarte registration example
+
+#
+# Security features
+#
+CONFIG_SECURE_BOOT_V1_SUPPORTED=y
+# CONFIG_SECURE_SIGNED_APPS_NO_SECURE_BOOT is not set
+# CONFIG_SECURE_BOOT is not set
+CONFIG_SECURE_FLASH_ENC_ENABLED=y
+CONFIG_SECURE_FLASH_ENCRYPTION_MODE_DEVELOPMENT=y
+# CONFIG_SECURE_FLASH_ENCRYPTION_MODE_RELEASE is not set
+
+#
+# Potentially insecure options
+#
+CONFIG_SECURE_BOOT_ALLOW_ROM_BASIC=y
+CONFIG_SECURE_BOOT_ALLOW_JTAG=y
+CONFIG_SECURE_FLASH_UART_BOOTLOADER_ALLOW_ENC=y
+CONFIG_SECURE_FLASH_UART_BOOTLOADER_ALLOW_DEC=y
+CONFIG_SECURE_FLASH_UART_BOOTLOADER_ALLOW_CACHE=y
+# CONFIG_SECURE_FLASH_REQUIRE_ALREADY_ENABLED is not set
+# end of Potentially insecure options
+
+# CONFIG_SECURE_FLASH_CHECK_ENC_EN_IN_APP is not set
+# end of Security features
+
+#
+# Partition Table
+#
+# CONFIG_PARTITION_TABLE_SINGLE_APP is not set
+# CONFIG_PARTITION_TABLE_SINGLE_APP_LARGE is not set
+# CONFIG_PARTITION_TABLE_TWO_OTA is not set
+CONFIG_PARTITION_TABLE_CUSTOM=y
+# CONFIG_PARTITION_TABLE_SINGLE_APP_ENCRYPTED_NVS is not set
+# CONFIG_PARTITION_TABLE_SINGLE_APP_LARGE_ENC_NVS is not set
+# CONFIG_PARTITION_TABLE_TWO_OTA_ENCRYPTED_NVS is not set
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions_example.csv"
+CONFIG_PARTITION_TABLE_FILENAME="partitions_example.csv"
+CONFIG_PARTITION_TABLE_OFFSET=0xB000
+CONFIG_PARTITION_TABLE_MD5=y
+# end of Partition Table

--- a/examples/non_volatile_storage/CMakeLists.txt
+++ b/examples/non_volatile_storage/CMakeLists.txt
@@ -1,0 +1,27 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2023 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later OR Apache-2.0
+#
+
+cmake_minimum_required(VERSION 3.5)
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+
+set(EXTRA_COMPONENT_DIRS ${CMAKE_SOURCE_DIR}/../..)
+
+project(non-volatile-storage)

--- a/examples/non_volatile_storage/Makefile
+++ b/examples/non_volatile_storage/Makefile
@@ -1,0 +1,24 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2023 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later OR Apache-2.0
+#
+
+PROJECT_NAME := non_volatile_storage
+EXTRA_COMPONENT_DIRS += $(PROJECT_PATH)/../../../
+
+include $(IDF_PATH)/make/project.mk

--- a/examples/non_volatile_storage/README.md
+++ b/examples/non_volatile_storage/README.md
@@ -1,0 +1,38 @@
+<!---
+  Copyright 2023 SECO Mind Srl
+
+  SPDX-License-Identifier: LGPL-2.1-or-later OR Apache-2.0
+-->
+
+# Astarte non volatile storage example
+
+This example will guide you through setting up a simple ESP32 application running the Astarte SDK
+configured to use an NVS partition for persistent storage.
+
+This example will perform the device registration starting from a provided JWT token.
+
+## Partition table
+
+The partition table used by this example is contained in `partitions_example.csv`.
+The only change from a regarding the SDK from a standard basic table is the addition of the
+`astarte` partition.
+
+Note that this table contains two NVS partitions. A generic `nvs` labelled partition and
+the `astarte` labelled partition. The `nvs` partition can be used by some ESP drivers such as the
+WIFI driver. We suggest creating a separate partition for the SDK data not to be shared with other
+components. This will prevent issues related memory sharing.
+
+Note that the `astarte` partition minimum size is not determined by the SDK memory requirements
+but by the minimum NVS partition sizes. Data partitions of NVS type are recommended to have a size
+of at least 12kB (0x3000) due to some NVS library limitations.
+
+## Enabling NVS in the example
+
+The following two lines of code are sufficient to instruct the SDK to use the NVS partition
+specified.
+```C
+nvs_flash_init_partition("astarte");
+astarte_credentials_use_nvs_storage("astarte");
+```
+Make sure you call `astarte_credentials_use_nvs_storage` before calling any other credentials
+related funcion.

--- a/examples/non_volatile_storage/interfaces/org.astarteplatform.esp32.examples.DeviceDatastream.json
+++ b/examples/non_volatile_storage/interfaces/org.astarteplatform.esp32.examples.DeviceDatastream.json
@@ -1,0 +1,13 @@
+{
+   "interface_name": "org.astarteplatform.esp32.examples.DeviceDatastream",
+   "version_major": 0,
+   "version_minor": 1,
+   "type": "datastream",
+   "ownership": "device",
+   "mappings": [
+       {
+           "endpoint": "/answer",
+           "type": "boolean"
+       }
+    ]
+}

--- a/examples/non_volatile_storage/interfaces/org.astarteplatform.esp32.examples.DeviceDatastream.json.license
+++ b/examples/non_volatile_storage/interfaces/org.astarteplatform.esp32.examples.DeviceDatastream.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 SECO Mind Srl
+
+SPDX-License-Identifier: LGPL-2.1-or-later OR Apache-2.0

--- a/examples/non_volatile_storage/interfaces/org.astarteplatform.esp32.examples.ServerDatastream.json
+++ b/examples/non_volatile_storage/interfaces/org.astarteplatform.esp32.examples.ServerDatastream.json
@@ -1,0 +1,13 @@
+{
+   "interface_name": "org.astarteplatform.esp32.examples.ServerDatastream",
+   "version_major": 0,
+   "version_minor": 1,
+   "type": "datastream",
+   "ownership": "server",
+   "mappings": [
+       {
+           "endpoint": "/question",
+           "type": "boolean"
+       }
+    ]
+}

--- a/examples/non_volatile_storage/interfaces/org.astarteplatform.esp32.examples.ServerDatastream.json.license
+++ b/examples/non_volatile_storage/interfaces/org.astarteplatform.esp32.examples.ServerDatastream.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 SECO Mind Srl
+
+SPDX-License-Identifier: LGPL-2.1-or-later OR Apache-2.0

--- a/examples/non_volatile_storage/main/CMakeLists.txt
+++ b/examples/non_volatile_storage/main/CMakeLists.txt
@@ -1,0 +1,27 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2023 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later OR Apache-2.0
+#
+
+idf_component_register(
+    SRCS
+        "app_main.c"
+        "./src/wifi_cfg.c"
+        "./src/example_task.c"
+    INCLUDE_DIRS "./include"
+    REQUIRES astarte-device-sdk-esp32 nvs_flash esp_event esp_wifi)

--- a/examples/non_volatile_storage/main/Kconfig.projbuild
+++ b/examples/non_volatile_storage/main/Kconfig.projbuild
@@ -1,0 +1,35 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2023 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later OR Apache-2.0
+#
+
+menu "Astarte non volatile storage example"
+
+config WIFI_SSID
+    string "WiFi SSID"
+    default "myssid"
+    help
+        SSID (network name) for the example to connect to.
+
+config WIFI_PASSWORD
+    string "WiFi Password"
+    default "mypassword"
+    help
+        WiFi password (WPA or WPA2) for the example to use.
+
+endmenu

--- a/examples/non_volatile_storage/main/app_main.c
+++ b/examples/non_volatile_storage/main/app_main.c
@@ -1,0 +1,56 @@
+/**
+ * This file is part of Astarte.
+ *
+ * Copyright 2023 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR Apache-2.0
+ *
+ **/
+
+#include <esp_idf_version.h>
+#include <esp_log.h>
+#include <inttypes.h>
+#include <nvs_flash.h>
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/event_groups.h"
+#include "freertos/queue.h"
+#include "freertos/task.h"
+
+#include "example_task.h"
+#include "wifi_cfg.h"
+
+/************************************************
+ * Constants/Defines
+ ***********************************************/
+
+#define TAG "NVS_EXAMPLE_APP_MAIN"
+
+/************************************************
+ * Main function definition
+ ***********************************************/
+
+void app_main()
+{
+    ESP_LOGI(TAG, "Startup..");
+    ESP_LOGI(TAG, "Free memory: %" PRIu32 " bytes", esp_get_free_heap_size());
+    ESP_LOGI(TAG, "IDF version: %s", esp_get_idf_version());
+
+    esp_log_level_set("*", ESP_LOG_INFO);
+
+    nvs_flash_init();
+    wifi_init();
+    xTaskCreate(astarte_example_task, "astarte_example_task", 6000, NULL, tskIDLE_PRIORITY, NULL);
+}

--- a/examples/non_volatile_storage/main/component.mk
+++ b/examples/non_volatile_storage/main/component.mk
@@ -1,0 +1,22 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2023 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later OR Apache-2.0
+#
+
+COMPONENT_ADD_INCLUDEDIRS += include
+COMPONENT_SRCDIRS += src

--- a/examples/non_volatile_storage/main/include/example_task.h
+++ b/examples/non_volatile_storage/main/include/example_task.h
@@ -1,0 +1,32 @@
+/**
+ * This file is part of Astarte.
+ *
+ * Copyright 2023 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR Apache-2.0
+ *
+ **/
+
+#ifndef EXAMPLE_TASK_H
+#define EXAMPLE_TASK_H
+
+/**
+ * @brief Astarte configuration task.
+ *
+ * @param ctx ESP 32 task context.
+ */
+void astarte_example_task(void *ctx);
+
+#endif /* EXAMPLE_TASK_H */

--- a/examples/non_volatile_storage/main/include/wifi_cfg.h
+++ b/examples/non_volatile_storage/main/include/wifi_cfg.h
@@ -1,0 +1,30 @@
+/**
+ * This file is part of Astarte.
+ *
+ * Copyright 2023 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR Apache-2.0
+ *
+ **/
+
+#ifndef WIFI_CFG_H
+#define WIFI_CFG_H
+
+/**
+ * @brief Wifi module initialization function.
+ */
+void wifi_init(void);
+
+#endif /* WIFI_CFG_H */

--- a/examples/non_volatile_storage/main/src/example_task.c
+++ b/examples/non_volatile_storage/main/src/example_task.c
@@ -1,0 +1,154 @@
+/**
+ * This file is part of Astarte.
+ *
+ * Copyright 2023 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR Apache-2.0
+ *
+ **/
+
+#include "example_task.h"
+
+#include <esp_idf_version.h>
+#include <esp_log.h>
+#include <nvs_flash.h>
+
+#include "astarte.h"
+#include "astarte_bson_types.h"
+#include "astarte_credentials.h"
+#include "astarte_device.h"
+#include "astarte_interface.h"
+
+/************************************************
+ * Constants and defines
+ ***********************************************/
+
+#define TAG "NVS_EXAMPLE_EXAMPLE_TASK"
+
+static const char realm[] = CONFIG_ASTARTE_REALM;
+
+const static astarte_interface_t device_datastream_interface = {
+    .name = "org.astarteplatform.esp32.examples.DeviceDatastream",
+    .major_version = 0,
+    .minor_version = 1,
+    .ownership = OWNERSHIP_DEVICE,
+    .type = TYPE_DATASTREAM,
+};
+
+const static astarte_interface_t server_datastream_interface = {
+    .name = "org.astarteplatform.esp32.examples.ServerDatastream",
+    .major_version = 0,
+    .minor_version = 1,
+    .ownership = OWNERSHIP_SERVER,
+    .type = TYPE_DATASTREAM,
+};
+
+/************************************************
+ * Static functions declaration
+ ***********************************************/
+
+/**
+ * @brief Handler for astarte connection events.
+ *
+ * @param event Astarte device connection event pointer.
+ */
+static void astarte_connection_events_handler(astarte_device_connection_event_t *event);
+/**
+ * @brief Handler for astarte data event.
+ *
+ * @param event Astarte device data event pointer.
+ */
+static void astarte_data_events_handler(astarte_device_data_event_t *event);
+/**
+ * @brief Handler for astarte disconnection events.
+ *
+ * @param event Astarte device disconnection event pointer.
+ */
+static void astarte_disconnection_events_handler(astarte_device_disconnection_event_t *event);
+
+/************************************************
+ * Global functions definition
+ ***********************************************/
+
+void astarte_example_task(void *ctx)
+{
+    (void) ctx;
+
+    nvs_flash_init_partition("astarte");
+    astarte_credentials_use_nvs_storage("astarte");
+
+    if (astarte_credentials_init() != ASTARTE_OK) {
+        ESP_LOGE(TAG, "Failed to initialize credentials");
+        return;
+    }
+    /*
+     * For additional ways to define the hwid of your device, see the documentation for
+     * the astarte_device_init function in astarte_device.h
+     *
+     */
+    astarte_device_config_t cfg = {
+        .data_event_callback = astarte_data_events_handler,
+        .connection_event_callback = astarte_connection_events_handler,
+        .disconnection_event_callback = astarte_disconnection_events_handler,
+        .realm = realm,
+    };
+
+    astarte_device_handle_t device = astarte_device_init(&cfg);
+    if (!device) {
+        ESP_LOGE(TAG, "Failed to init astarte device");
+        return;
+    }
+
+    astarte_device_add_interface(device, &device_datastream_interface);
+    astarte_device_add_interface(device, &server_datastream_interface);
+    if (astarte_device_start(device) != ASTARTE_OK) {
+        ESP_LOGE(TAG, "Failed to start astarte device");
+        return;
+    }
+
+    ESP_LOGI(TAG, "Encoded device ID: %s", astarte_device_get_encoded_id(device));
+    while (1) {
+    }
+}
+
+/************************************************
+ * Static functions definitions
+ ***********************************************/
+
+static void astarte_connection_events_handler(astarte_device_connection_event_t *event)
+{
+    ESP_LOGI(TAG, "Astarte device connected, session_present: %d", event->session_present);
+}
+
+static void astarte_data_events_handler(astarte_device_data_event_t *event)
+{
+    ESP_LOGI(TAG, "Got Astarte data event, interface_name: %s, path: %s, bson_type: %d",
+        event->interface_name, event->path, event->bson_element.type);
+
+    if (strcmp(event->interface_name, "org.astarteplatform.esp32.examples.ServerDatastream") == 0
+        && strcmp(event->path, "/question") == 0 && event->bson_element.type == BSON_TYPE_BOOLEAN) {
+        bool answer = !astarte_bson_deserializer_element_to_bool(event->bson_element);
+        ESP_LOGI(TAG, "Sending answer %d.", answer);
+        astarte_device_stream_boolean(event->device,
+            "org.astarteplatform.esp32.examples.DeviceDatastream", "/answer", answer, 0);
+    }
+}
+
+static void astarte_disconnection_events_handler(astarte_device_disconnection_event_t *event)
+{
+    (void) event;
+
+    ESP_LOGI(TAG, "Astarte device disconnected");
+}

--- a/examples/non_volatile_storage/main/src/wifi_cfg.c
+++ b/examples/non_volatile_storage/main/src/wifi_cfg.c
@@ -1,0 +1,113 @@
+/**
+ * This file is part of Astarte.
+ *
+ * Copyright 2023 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR Apache-2.0
+ *
+ **/
+
+#include "wifi_cfg.h"
+
+#include <esp_idf_version.h>
+#include <esp_log.h>
+#include <esp_wifi.h>
+
+#include "freertos/event_groups.h"
+#include "freertos/task.h"
+
+/************************************************
+ * Constants/Defines
+ ***********************************************/
+
+#define TAG "NVS_EXAMPLE_WIFI_CFG"
+
+static EventGroupHandle_t wifi_event_group;
+const static int connected_bit = BIT0;
+
+/************************************************
+ * Static functions declaration
+ ***********************************************/
+
+/**
+ * @brief Wifi event handler for the ESP32 wifi.
+ *
+ * @details To be installed in an event loop.
+ * @param arg Remaining handler arguments.
+ * @param event_base event base.
+ * @param event_id event identifier.
+ * @param event_data event data.
+ * @return The status code, ASTARTE_OK if successful, otherwise an error code is returned.
+ */
+static void wifi_event_handler(
+    void *arg, esp_event_base_t event_base, int32_t event_id, void *event_data);
+
+/************************************************
+ * Global functions definition
+ ***********************************************/
+
+void wifi_init(void)
+{
+    wifi_event_group = xEventGroupCreate();
+
+    ESP_ERROR_CHECK(esp_netif_init());
+
+    ESP_ERROR_CHECK(esp_event_loop_create_default());
+    esp_netif_create_default_wifi_sta();
+
+    wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
+    ESP_ERROR_CHECK(esp_wifi_init(&cfg));
+
+    esp_event_handler_instance_t instance_any_id = NULL;
+    esp_event_handler_instance_t instance_got_ip = NULL;
+    ESP_ERROR_CHECK(esp_event_handler_instance_register(
+        WIFI_EVENT, ESP_EVENT_ANY_ID, &wifi_event_handler, NULL, &instance_any_id));
+    ESP_ERROR_CHECK(esp_event_handler_instance_register(
+        IP_EVENT, IP_EVENT_STA_GOT_IP, &wifi_event_handler, NULL, &instance_got_ip));
+
+    ESP_ERROR_CHECK(esp_wifi_set_storage(WIFI_STORAGE_RAM));
+    wifi_config_t wifi_config = {
+        .sta = {
+            .ssid = CONFIG_WIFI_SSID,
+            .password = CONFIG_WIFI_PASSWORD,
+        },
+    };
+    ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
+    ESP_ERROR_CHECK(esp_wifi_set_config(ESP_IF_WIFI_STA, &wifi_config));
+    ESP_LOGI(TAG, "start the WIFI SSID:[%s] password:[%s]", CONFIG_WIFI_SSID, "******");
+    ESP_ERROR_CHECK(esp_wifi_start());
+    ESP_LOGI(TAG, "Waiting for wifi");
+    xEventGroupWaitBits(wifi_event_group, connected_bit, false, true, portMAX_DELAY);
+}
+
+/************************************************
+ * Static functions definitions
+ ***********************************************/
+
+static void wifi_event_handler(
+    void *arg, esp_event_base_t event_base, int32_t event_id, void *event_data)
+{
+    (void) arg;
+    (void) event_data;
+
+    if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_START) {
+        esp_wifi_connect();
+    } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_DISCONNECTED) {
+        esp_wifi_connect();
+        xEventGroupClearBits(wifi_event_group, connected_bit);
+    } else if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP) {
+        xEventGroupSetBits(wifi_event_group, connected_bit);
+    }
+}

--- a/examples/non_volatile_storage/partitions_example.csv
+++ b/examples/non_volatile_storage/partitions_example.csv
@@ -1,0 +1,24 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2023 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later OR Apache-2.0
+#
+
+# Name,   Type, SubType, Offset,  Size, Flags
+nvs,      data, nvs,     ,        0x6000,
+factory,  app,  factory, ,        1500K,
+astarte,  data, nvs,     ,        0x3000,

--- a/examples/non_volatile_storage/sdkconfig.defaults
+++ b/examples/non_volatile_storage/sdkconfig.defaults
@@ -1,0 +1,45 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2023 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later OR Apache-2.0
+#
+
+CONFIG_PARTITION_TABLE_CUSTOM=y
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions_example.csv"
+CONFIG_PARTITION_TABLE_CUSTOM_APP_BIN_OFFSET=0x10000
+CONFIG_PARTITION_TABLE_FILENAME="partitions_example.csv"
+CONFIG_APP_OFFSET=0x10000
+CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y
+
+#
+# Astarte SDK
+#
+CONFIG_ASTARTE_REALM=""
+CONFIG_ASTARTE_PAIRING_BASE_URL=""
+CONFIG_ASTARTE_PAIRING_JWT=""
+CONFIG_ASTARTE_PAIRING_JWT_MAX_LEN=1024
+CONFIG_ASTARTE_CONNECTIVITY_TEST_URL="http://www.example.com"
+CONFIG_ASTARTE_HWID_ENABLE_UUID=y
+CONFIG_ASTARTE_HWID_UUID_NAMESPACE="30349dbb-85b6-489e-a8ed-532e65c55c38"
+# end of Astarte SDK
+
+#
+# Astarte non volatile storage example
+#
+CONFIG_WIFI_SSID=""
+CONFIG_WIFI_PASSWORD=""
+# end of Astarte non volatile storage example

--- a/examples/registration/CMakeLists.txt
+++ b/examples/registration/CMakeLists.txt
@@ -1,0 +1,27 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2023 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later OR Apache-2.0
+#
+
+cmake_minimum_required(VERSION 3.5)
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+
+set(EXTRA_COMPONENT_DIRS ${CMAKE_SOURCE_DIR}/../..)
+
+project(registration)

--- a/examples/registration/Makefile
+++ b/examples/registration/Makefile
@@ -1,0 +1,24 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2023 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later OR Apache-2.0
+#
+
+PROJECT_NAME := registration
+EXTRA_COMPONENT_DIRS += $(PROJECT_PATH)/../../../
+
+include $(IDF_PATH)/make/project.mk

--- a/examples/registration/README.md
+++ b/examples/registration/README.md
@@ -1,0 +1,20 @@
+<!---
+  Copyright 2023 SECO Mind Srl
+
+  SPDX-License-Identifier: LGPL-2.1-or-later OR Apache-2.0
+-->
+
+# Astarte device registration example
+
+This example will guide you through setting up a simple ESP32 application running the Astarte SDK
+and interacting with a local instance of Astarte.
+
+We will configure the device to auto-register in the local Astarte instance at the first start-up.
+
+## Checking the connection status of the device in Astarte
+
+`astartectl` can be used to check the connection status of the device on the local Astarte instance:
+```
+astartectl appengine devices show <DEVICE ID> --appengine-url http://localhost:4002
+    -r test -k test_private.pem
+```

--- a/examples/registration/interfaces/org.astarteplatform.esp32.examples.DeviceDatastream.json
+++ b/examples/registration/interfaces/org.astarteplatform.esp32.examples.DeviceDatastream.json
@@ -1,0 +1,13 @@
+{
+   "interface_name": "org.astarteplatform.esp32.examples.DeviceDatastream",
+   "version_major": 0,
+   "version_minor": 1,
+   "type": "datastream",
+   "ownership": "device",
+   "mappings": [
+       {
+           "endpoint": "/boolean_endpoint",
+           "type": "boolean"
+       }
+    ]
+}

--- a/examples/registration/interfaces/org.astarteplatform.esp32.examples.DeviceDatastream.json.license
+++ b/examples/registration/interfaces/org.astarteplatform.esp32.examples.DeviceDatastream.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 SECO Mind Srl
+
+SPDX-License-Identifier: LGPL-2.1-or-later OR Apache-2.0

--- a/examples/registration/interfaces/org.astarteplatform.esp32.examples.ServerDatastream.json
+++ b/examples/registration/interfaces/org.astarteplatform.esp32.examples.ServerDatastream.json
@@ -1,0 +1,13 @@
+{
+   "interface_name": "org.astarteplatform.esp32.examples.ServerDatastream",
+   "version_major": 0,
+   "version_minor": 1,
+   "type": "datastream",
+   "ownership": "server",
+   "mappings": [
+       {
+           "endpoint": "/boolean_endpoint",
+           "type": "boolean"
+       }
+    ]
+}

--- a/examples/registration/interfaces/org.astarteplatform.esp32.examples.ServerDatastream.json.license
+++ b/examples/registration/interfaces/org.astarteplatform.esp32.examples.ServerDatastream.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 SECO Mind Srl
+
+SPDX-License-Identifier: LGPL-2.1-or-later OR Apache-2.0

--- a/examples/registration/main/CMakeLists.txt
+++ b/examples/registration/main/CMakeLists.txt
@@ -1,0 +1,27 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2023 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later OR Apache-2.0
+#
+
+idf_component_register(
+    SRCS
+        "app_main.c"
+        "./src/wifi_cfg.c"
+        "./src/example_task.c"
+    INCLUDE_DIRS "./include"
+    REQUIRES astarte-device-sdk-esp32 nvs_flash esp_event esp_wifi driver)

--- a/examples/registration/main/Kconfig.projbuild
+++ b/examples/registration/main/Kconfig.projbuild
@@ -1,0 +1,35 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2023 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later OR Apache-2.0
+#
+
+menu "Astarte registration example"
+
+config WIFI_SSID
+    string "WiFi SSID"
+    default "myssid"
+    help
+        SSID (network name) for the example to connect to.
+
+config WIFI_PASSWORD
+    string "WiFi Password"
+    default "mypassword"
+    help
+        WiFi password (WPA or WPA2) for the example to use.
+
+endmenu

--- a/examples/registration/main/app_main.c
+++ b/examples/registration/main/app_main.c
@@ -1,0 +1,56 @@
+/**
+ * This file is part of Astarte.
+ *
+ * Copyright 2023 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR Apache-2.0
+ *
+ **/
+
+#include <esp_idf_version.h>
+#include <esp_log.h>
+#include <inttypes.h>
+#include <nvs_flash.h>
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/event_groups.h"
+#include "freertos/queue.h"
+#include "freertos/task.h"
+
+#include "example_task.h"
+#include "wifi_cfg.h"
+
+/************************************************
+ * Constants/Defines
+ ***********************************************/
+
+#define TAG "REGISTRATION_EXAMPLE_APP_MAIN"
+
+/************************************************
+ * Main function definition
+ ***********************************************/
+
+void app_main()
+{
+    ESP_LOGI(TAG, "Startup..");
+    ESP_LOGI(TAG, "Free memory: %" PRIu32 " bytes", esp_get_free_heap_size());
+    ESP_LOGI(TAG, "IDF version: %s", esp_get_idf_version());
+
+    esp_log_level_set("*", ESP_LOG_INFO);
+
+    nvs_flash_init();
+    wifi_init();
+    xTaskCreate(astarte_example_task, "astarte_example_task", 6000, NULL, tskIDLE_PRIORITY, NULL);
+}

--- a/examples/registration/main/component.mk
+++ b/examples/registration/main/component.mk
@@ -1,0 +1,22 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2023 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later OR Apache-2.0
+#
+
+COMPONENT_ADD_INCLUDEDIRS += include
+COMPONENT_SRCDIRS += src

--- a/examples/registration/main/include/example_task.h
+++ b/examples/registration/main/include/example_task.h
@@ -1,0 +1,32 @@
+/**
+ * This file is part of Astarte.
+ *
+ * Copyright 2023 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR Apache-2.0
+ *
+ **/
+
+#ifndef EXAMPLE_TASK_H
+#define EXAMPLE_TASK_H
+
+/**
+ * @brief Astarte configuration task.
+ *
+ * @param ctx ESP 32 task context.
+ */
+void astarte_example_task(void *ctx);
+
+#endif /* EXAMPLE_TASK_H */

--- a/examples/registration/main/include/wifi_cfg.h
+++ b/examples/registration/main/include/wifi_cfg.h
@@ -1,0 +1,30 @@
+/**
+ * This file is part of Astarte.
+ *
+ * Copyright 2023 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR Apache-2.0
+ *
+ **/
+
+#ifndef WIFI_CFG_H
+#define WIFI_CFG_H
+
+/**
+ * @brief Wifi module initialization function.
+ */
+void wifi_init(void);
+
+#endif /* WIFI_CFG_H */

--- a/examples/registration/main/src/example_task.c
+++ b/examples/registration/main/src/example_task.c
@@ -1,0 +1,138 @@
+/**
+ * This file is part of Astarte.
+ *
+ * Copyright 2023 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR Apache-2.0
+ *
+ **/
+
+#include "example_task.h"
+
+#include <esp_idf_version.h>
+#include <esp_log.h>
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/queue.h"
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0)
+#include "freertos/task.h"
+#endif
+
+#include "astarte_bson_types.h"
+#include "astarte_credentials.h"
+#include "astarte_device.h"
+
+/************************************************
+ * Constants and defines
+ ***********************************************/
+
+#define TAG "REGISTRATION_EXAMPLE_EXAMPLE_TASK"
+
+const static astarte_interface_t device_datastream_interface = {
+    .name = "org.astarteplatform.esp32.examples.DeviceDatastream",
+    .major_version = 0,
+    .minor_version = 1,
+    .ownership = OWNERSHIP_DEVICE,
+    .type = TYPE_DATASTREAM,
+};
+
+const static astarte_interface_t server_datastream_interface = {
+    .name = "org.astarteplatform.esp32.examples.ServerDatastream",
+    .major_version = 0,
+    .minor_version = 1,
+    .ownership = OWNERSHIP_SERVER,
+    .type = TYPE_DATASTREAM,
+};
+
+/************************************************
+ * Static functions declaration
+ ***********************************************/
+
+/**
+ * @brief Handler for astarte connection events.
+ *
+ * @param event Astarte device connection event pointer.
+ */
+static void astarte_connection_events_handler(astarte_device_connection_event_t *event);
+/**
+ * @brief Handler for astarte data event.
+ *
+ * @param event Astarte device data event pointer.
+ */
+static void astarte_data_events_handler(astarte_device_data_event_t *event);
+/**
+ * @brief Handler for astarte disconnection events.
+ *
+ * @param event Astarte device disconnection event pointer.
+ */
+static void astarte_disconnection_events_handler(astarte_device_disconnection_event_t *event);
+
+/************************************************
+ * Global functions definition
+ ***********************************************/
+
+void astarte_example_task(void *ctx)
+{
+    (void) ctx;
+
+    if (astarte_credentials_init() != ASTARTE_OK) {
+        ESP_LOGE(TAG, "Failed to initialize credentials");
+        return;
+    }
+    astarte_device_config_t cfg = {
+        .data_event_callback = astarte_data_events_handler,
+        .connection_event_callback = astarte_connection_events_handler,
+        .disconnection_event_callback = astarte_disconnection_events_handler,
+    };
+
+    astarte_device_handle_t device = astarte_device_init(&cfg);
+    if (!device) {
+        ESP_LOGE(TAG, "Failed to init astarte device");
+        return;
+    }
+
+    astarte_device_add_interface(device, &device_datastream_interface);
+    astarte_device_add_interface(device, &server_datastream_interface);
+    if (astarte_device_start(device) != ASTARTE_OK) {
+        ESP_LOGE(TAG, "Failed to start astarte device");
+        return;
+    }
+
+    ESP_LOGI(TAG, "Encoded device ID: %s", astarte_device_get_encoded_id(device));
+
+    while (1) {
+    }
+}
+
+/************************************************
+ * Static functions definitions
+ ***********************************************/
+
+static void astarte_connection_events_handler(astarte_device_connection_event_t *event)
+{
+    ESP_LOGI(TAG, "Astarte device connected, session_present: %d", event->session_present);
+}
+
+static void astarte_data_events_handler(astarte_device_data_event_t *event)
+{
+    ESP_LOGI(TAG, "Got Astarte data event, interface_name: %s, path: %s, bson_type: %d",
+        event->interface_name, event->path, event->bson_element.type);
+}
+
+static void astarte_disconnection_events_handler(astarte_device_disconnection_event_t *event)
+{
+    (void) event;
+    ESP_LOGI(TAG, "Astarte device disconnected");
+}

--- a/examples/registration/main/src/wifi_cfg.c
+++ b/examples/registration/main/src/wifi_cfg.c
@@ -1,0 +1,113 @@
+/**
+ * This file is part of Astarte.
+ *
+ * Copyright 2023 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR Apache-2.0
+ *
+ **/
+
+#include "wifi_cfg.h"
+
+#include <esp_idf_version.h>
+#include <esp_log.h>
+#include <esp_wifi.h>
+
+#include "freertos/event_groups.h"
+#include "freertos/task.h"
+
+/************************************************
+ * Constants/Defines
+ ***********************************************/
+
+#define TAG "REGISTRATION_EXAMPLE_WIFI_CFG"
+
+static EventGroupHandle_t wifi_event_group;
+const static int connected_bit = BIT0;
+
+/************************************************
+ * Static functions declaration
+ ***********************************************/
+
+/**
+ * @brief Wifi event handler for the ESP32 wifi.
+ *
+ * @details To be installed in an event loop.
+ * @param arg Remaining handler arguments.
+ * @param event_base event base.
+ * @param event_id event identifier.
+ * @param event_data event data.
+ * @return The status code, ASTARTE_OK if successful, otherwise an error code is returned.
+ */
+static void wifi_event_handler(
+    void *arg, esp_event_base_t event_base, int32_t event_id, void *event_data);
+
+/************************************************
+ * Global functions definition
+ ***********************************************/
+
+void wifi_init(void)
+{
+    wifi_event_group = xEventGroupCreate();
+
+    ESP_ERROR_CHECK(esp_netif_init());
+
+    ESP_ERROR_CHECK(esp_event_loop_create_default());
+    esp_netif_create_default_wifi_sta();
+
+    wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
+    ESP_ERROR_CHECK(esp_wifi_init(&cfg));
+
+    esp_event_handler_instance_t instance_any_id = NULL;
+    esp_event_handler_instance_t instance_got_ip = NULL;
+    ESP_ERROR_CHECK(esp_event_handler_instance_register(
+        WIFI_EVENT, ESP_EVENT_ANY_ID, &wifi_event_handler, NULL, &instance_any_id));
+    ESP_ERROR_CHECK(esp_event_handler_instance_register(
+        IP_EVENT, IP_EVENT_STA_GOT_IP, &wifi_event_handler, NULL, &instance_got_ip));
+
+    ESP_ERROR_CHECK(esp_wifi_set_storage(WIFI_STORAGE_RAM));
+    wifi_config_t wifi_config = {
+        .sta = {
+            .ssid = CONFIG_WIFI_SSID,
+            .password = CONFIG_WIFI_PASSWORD,
+        },
+    };
+    ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
+    ESP_ERROR_CHECK(esp_wifi_set_config(ESP_IF_WIFI_STA, &wifi_config));
+    ESP_LOGI(TAG, "start the WIFI SSID:[%s] password:[%s]", CONFIG_WIFI_SSID, "******");
+    ESP_ERROR_CHECK(esp_wifi_start());
+    ESP_LOGI(TAG, "Waiting for wifi");
+    xEventGroupWaitBits(wifi_event_group, connected_bit, false, true, portMAX_DELAY);
+}
+
+/************************************************
+ * Static functions definitions
+ ***********************************************/
+
+static void wifi_event_handler(
+    void *arg, esp_event_base_t event_base, int32_t event_id, void *event_data)
+{
+    (void) arg;
+    (void) event_data;
+
+    if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_START) {
+        esp_wifi_connect();
+    } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_DISCONNECTED) {
+        esp_wifi_connect();
+        xEventGroupClearBits(wifi_event_group, connected_bit);
+    } else if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP) {
+        xEventGroupSetBits(wifi_event_group, connected_bit);
+    }
+}

--- a/examples/registration/partitions_example.csv
+++ b/examples/registration/partitions_example.csv
@@ -1,0 +1,25 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2023 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later OR Apache-2.0
+#
+
+# Name,   Type, SubType, Offset,  Size, Flags
+nvs,      data, nvs,     ,        0x6000,
+phy_init, data, phy,     ,        0x1000,
+factory,  app,  factory, ,        1500K,
+astarte,  data, fat,     ,        1M,

--- a/examples/registration/sdkconfig.defaults
+++ b/examples/registration/sdkconfig.defaults
@@ -1,0 +1,26 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2023 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later OR Apache-2.0
+#
+
+CONFIG_PARTITION_TABLE_CUSTOM=y
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions_example.csv"
+CONFIG_PARTITION_TABLE_CUSTOM_APP_BIN_OFFSET=0x10000
+CONFIG_PARTITION_TABLE_FILENAME="partitions_example.csv"
+CONFIG_APP_OFFSET=0x10000
+CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y


### PR DESCRIPTION
Introduce three new examples:
- An example using NVS instead of FAT for persistent storage.
- An example of using encryption on all the required partitions.
- An example registering a device with the use of a pairing token.

Closes #178 