### PR TITLE
Initialize strings

### DIFF
--- a/include/astarte_device.h
+++ b/include/astarte_device.h
@@ -108,7 +108,7 @@ extern "C" {
  *  const char *unique_data = "my_unique_data"
  *  uuid_generate_v5(uuid_ns, unique_data, strlen(unique_data), device_uuid);
  *
- *  char hwid[32];
+ *  char hwid[32] = { 0 };
  *  astarte_hwid_encode(hwid, sizeof(hwid), device_uuid);
  *
  *  astarte_device_config_t cfg = {

--- a/src/astarte_bson_serializer.c
+++ b/src/astarte_bson_serializer.c
@@ -292,7 +292,7 @@ void astarte_bson_serializer_append_document(
         astarte_err_t result = ASTARTE_OK;                                                         \
         astarte_bson_serializer_handle_t array_ser = astarte_bson_serializer_new();                \
         for (int i = 0; i < count; i++) {                                                          \
-            char key[BSON_ARRAY_SIZE_STR_LEN];                                                     \
+            char key[BSON_ARRAY_SIZE_STR_LEN] = { 0 };                                             \
             int ret = snprintf(key, BSON_ARRAY_SIZE_STR_LEN, "%i", i);                             \
             if ((ret < 0) || (ret >= BSON_ARRAY_SIZE_STR_LEN)) {                                   \
                 result = ASTARTE_ERR;                                                              \
@@ -327,7 +327,7 @@ astarte_err_t astarte_bson_serializer_append_binary_array(astarte_bson_serialize
     astarte_err_t result = ASTARTE_OK;
     astarte_bson_serializer_handle_t array_ser = astarte_bson_serializer_new();
     for (int i = 0; i < count; i++) {
-        char key[BSON_ARRAY_SIZE_STR_LEN];
+        char key[BSON_ARRAY_SIZE_STR_LEN] = { 0 };
         int ret = snprintf(key, BSON_ARRAY_SIZE_STR_LEN, "%i", i);
         if ((ret < 0) || (ret >= BSON_ARRAY_SIZE_STR_LEN)) {
             result = ASTARTE_ERR;

--- a/src/astarte_device.c
+++ b/src/astarte_device.c
@@ -36,8 +36,9 @@
 #define CN_LENGTH 512
 #define PRIVKEY_LENGTH 8196
 #define URL_LENGTH 512
-#define INTROSPECTION_INTERFACE_LENGTH 512
 #define TOPIC_LENGTH 512
+#define INTERFACE_LENGTH 512
+#define PATH_LENGTH 512
 #define REINIT_RETRY_INTERVAL_MS (30 * 1000)
 
 #define NOTIFY_TERMINATE (1U << 0U)
@@ -134,7 +135,7 @@ astarte_device_handle_t astarte_device_init(astarte_device_config_t *cfg)
             ESP_LOGE(TAG, "Cannot get device HWID: %d", hwid_err);
             goto init_failed;
         }
-        char generated_encoded_hwid[ENCODED_HWID_LENGTH];
+        char generated_encoded_hwid[ENCODED_HWID_LENGTH] = { 0 };
         hwid_err = astarte_hwid_encode(generated_encoded_hwid, ENCODED_HWID_LENGTH, generated_hwid);
         if (hwid_err != ASTARTE_OK) {
             ESP_LOGE(TAG, "Cannot encode device HWID: %d", hwid_err);
@@ -303,7 +304,7 @@ astarte_err_t astarte_device_init_connection(
         pairing_config.credentials_secret = device->credentials_secret;
     }
 
-    char credentials_secret[CREDENTIALS_SECRET_LENGTH];
+    char credentials_secret[CREDENTIALS_SECRET_LENGTH] = { 0 };
     astarte_err_t err = astarte_pairing_get_credentials_secret(
         &pairing_config, credentials_secret, CREDENTIALS_SECRET_LENGTH);
     if (err != ASTARTE_OK) {
@@ -364,7 +365,7 @@ astarte_err_t astarte_device_init_connection(
         ESP_LOGD(TAG, "Device topic is: %s", client_cert_cn);
     }
 
-    char broker_url[URL_LENGTH];
+    char broker_url[URL_LENGTH] = { 0 };
     err = astarte_pairing_get_mqtt_v1_broker_url(&pairing_config, broker_url, URL_LENGTH);
     if (err != ASTARTE_OK) {
         ESP_LOGE(TAG, "Error in get_mqtt_v1_broker_url");
@@ -635,7 +636,7 @@ static astarte_err_t publish_data(astarte_device_handle_t device, const char *in
         return ASTARTE_ERR_INVALID_QOS;
     }
 
-    char topic[TOPIC_LENGTH];
+    char topic[TOPIC_LENGTH] = { 0 };
     int print_ret
         = snprintf(topic, TOPIC_LENGTH, "%s/%s%s", device->device_topic, interface_name, path);
     if ((print_ret < 0) || (print_ret >= TOPIC_LENGTH)) {
@@ -1109,7 +1110,7 @@ static void setup_subscriptions(astarte_device_handle_t device)
         return;
     }
 
-    char topic[TOPIC_LENGTH];
+    char topic[TOPIC_LENGTH] = { 0 };
 
     esp_mqtt_client_handle_t mqtt = device->mqtt_client;
 
@@ -1152,7 +1153,7 @@ static void send_emptycache(astarte_device_handle_t device)
 
     esp_mqtt_client_handle_t mqtt = device->mqtt_client;
 
-    char topic[TOPIC_LENGTH];
+    char topic[TOPIC_LENGTH] = { 0 };
     int ret = snprintf(topic, TOPIC_LENGTH, "%s/control/emptyCache", device->device_topic);
     if ((ret < 0) || (ret >= TOPIC_LENGTH)) {
         ESP_LOGE(TAG, "Error encoding topic");
@@ -1377,7 +1378,7 @@ static void send_purge_device_properties(
     }
 
     // Compose MQTT topic
-    char topic[TOPIC_LENGTH];
+    char topic[TOPIC_LENGTH] = { 0 };
     int ret = snprintf(topic, TOPIC_LENGTH, "%s/control/producer/properties", device->device_topic);
     if ((ret < 0) || (ret >= TOPIC_LENGTH)) {
         ESP_LOGE(TAG, "Error encoding topic");
@@ -1453,11 +1454,9 @@ static void on_incoming(
         return;
     }
 
-    const size_t maximum_control_prefix_len = 512;
-    char control_prefix[maximum_control_prefix_len];
-    int ret
-        = snprintf(control_prefix, maximum_control_prefix_len, "%s/control", device->device_topic);
-    if ((ret < 0) || (ret >= maximum_control_prefix_len)) {
+    char control_prefix[TOPIC_LENGTH] = { 0 };
+    int ret = snprintf(control_prefix, TOPIC_LENGTH, "%s/control", device->device_topic);
+    if ((ret < 0) || (ret >= TOPIC_LENGTH)) {
         ESP_LOGE(TAG, "Error encoding control prefix");
         return;
     }
@@ -1486,20 +1485,18 @@ static void on_incoming(
     }
 
     int interface_name_len = path_begin - interface_name_begin;
-    const size_t maximum_interface_name_len = 512;
-    char interface_name[maximum_interface_name_len];
-    ret = snprintf(interface_name, maximum_interface_name_len, "%.*s", interface_name_len,
-        interface_name_begin);
-    if ((ret < 0) || (ret >= maximum_interface_name_len)) {
+    char interface_name[INTERFACE_LENGTH] = { 0 };
+    ret = snprintf(
+        interface_name, INTERFACE_LENGTH, "%.*s", interface_name_len, interface_name_begin);
+    if ((ret < 0) || (ret >= INTERFACE_LENGTH)) {
         ESP_LOGE(TAG, "Error encoding interface name");
         return;
     }
 
     size_t path_len = topic_len - device->device_topic_len - strlen("/") - interface_name_len;
-    const size_t maximum_path_len = 512;
-    char path[maximum_path_len];
-    ret = snprintf(path, maximum_path_len, "%.*s", path_len, path_begin);
-    if ((ret < 0) || (ret >= maximum_path_len)) {
+    char path[PATH_LENGTH] = { 0 };
+    ret = snprintf(path, PATH_LENGTH, "%.*s", path_len, path_begin);
+    if ((ret < 0) || (ret >= PATH_LENGTH)) {
         ESP_LOGE(TAG, "Error encoding path");
         return;
     }

--- a/src/astarte_hwid.c
+++ b/src/astarte_hwid.c
@@ -20,6 +20,7 @@
 #include <mbedtls/md.h>
 
 #define HWID_LEN 16
+#define INFO_STRING_MAX_LEN 160
 
 #define TAG "ASTARTE_HWID"
 
@@ -35,8 +36,7 @@ astarte_err_t astarte_hwid_get_id(uint8_t *hardware_id)
     esp_chip_info_t chip_info;
     esp_chip_info(&chip_info);
 
-    const size_t info_string_max_len = 160;
-    char info_string[info_string_max_len];
+    char info_string[INFO_STRING_MAX_LEN] = { 0 };
 
     // CHIP_FEATURE_EMB_FLASH, CHIP_FEATURE_BT and CHIP_FEATURE_BLE are part of the esp-idf lib.
     // NOLINTBEGIN(hicpp-signed-bitwise)
@@ -54,14 +54,14 @@ astarte_err_t astarte_hwid_get_id(uint8_t *hardware_id)
 #endif
 
     // NOLINTBEGIN(readability-magic-numbers)
-    int res = snprintf(info_string, info_string_max_len,
+    int res = snprintf(info_string, INFO_STRING_MAX_LEN,
         "ESP_MAC_WIFI_STA: %02x:%02x:%02x:%02x:%02x:%02x, model: %i, cores: %i, revision: %i "
         "embedded flash: %i, bluetooth: %i, BLE: %i.",
         (unsigned int) mac_addr[0], (unsigned int) mac_addr[1], (unsigned int) mac_addr[2],
         (unsigned int) mac_addr[3], (unsigned int) mac_addr[4], (unsigned int) mac_addr[5],
         chip_info.model, chip_info.cores, revision, embedded_flash, bluetooth, ble);
     // NOLINTEND(readability-magic-numbers)
-    if ((res < 0) || (res >= info_string_max_len)) {
+    if ((res < 0) || (res >= INFO_STRING_MAX_LEN)) {
         ESP_LOGE(TAG, "Error generating the encoding device specific info string.");
         return ASTARTE_ERR;
     }

--- a/src/uuid.c
+++ b/src/uuid.c
@@ -204,7 +204,7 @@ int uuid_from_string(const char *input, uuid_t out)
     }
 
     // Will be used to contain the string representation of a uint16_t (plus the NULL terminator)
-    char tmp[sizeof(uint16_t) + sizeof(uint8_t)];
+    char tmp[sizeof(uint16_t) + sizeof(uint8_t)] = { 0 };
     struct uuid uuid_struct;
     const int strtoul_base = 16;
 


### PR DESCRIPTION
Initialize local arrays of char to 0. 
They are often used as strings and some functions might assume them to be null-terminated from the start.